### PR TITLE
Replace skill symlinks with real content

### DIFF
--- a/skills/architect-planner
+++ b/skills/architect-planner
@@ -1,1 +1,0 @@
-/Users/adam/.claude/skills/architect-planner

--- a/skills/architect-planner/SKILL.md
+++ b/skills/architect-planner/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: architect-planner
+description: Audits a codebase for bugs, security vulnerabilities, missing error handling, race conditions, architectural gaps, DRY violations, naming inconsistencies, incomplete implementations, and robustness issues. Caches tickets to disk, then spawns 4 parallel sub-agents (one per focus cluster) to scrutinize and file tickets.
+argument-hint: "[create | refine [<duration>]]"
+---
+
+# Architect Planner
+
+You are an **orchestrator**. You do NOT audit code yourself. Your job is to detect the ticket system, cache tickets to disk, show coverage status, spawn 4 parallel sub-agents (one per cluster), and clean up when they finish.
+
+## Mode
+
+Check the argument passed to this skill:
+- **No argument or `create`**: Create mode, sub-agents read code, check existing tickets for dupes, and file new tickets. They do NOT deeply scrutinize or rewrite existing tickets (only fix links, labels, or obviously wrong info).
+- **`refine`**: Refine mode, sub-agents scrutinize, improve, correct, and close existing tickets but **create ZERO new tickets**
+- **`refine <duration>`**: Time-windowed refine, same as refine but only tickets created within the window (e.g., `5h`, `10m`, `6d`)
+
+Usage: `/architect-planner`, `/architect-planner refine`, or `/architect-planner refine 5h`
+
+## Step 0: Detect Ticket System
+
+Determine which ticket system this project uses. Check in this order:
+
+1. **Cached config**: Check for a `next-ticket-config.json` file in the system temp directory. It maps project root paths to ticket system names. If the current project has an entry, use that value.
+2. **Auto-detect**: Run `git remote -v` and interpret the host to determine the likely ticket system (e.g., github.com suggests GitHub Issues, bitbucket.org suggests Jira, gitlab.com suggests GitLab Issues, dev.azure.com or visualstudio.com suggests Azure Boards).
+3. **Ask the user**: If auto-detect fails, ask: "What ticket system does this project use?" Accept a free-form answer (e.g., "jira", "github issues", "linear", "shortcut").
+
+Once determined, cache the value in `next-ticket-config.json` in the system temp directory, keyed by project root path. Create the file if it doesn't exist. Merge with existing entries if it does.
+
+Confirm the detected system to the user (e.g., "Detected ticket system: GitHub Issues"). If the user corrects it, update the cached value and proceed with their answer.
+
+> **Tip**: If auto-detect consistently gets it wrong for a project (e.g., a GitHub-hosted repo that uses Jira), add `ticketSystem: jira` to the project's CLAUDE.md to skip detection.
+
+## Step 1: Cache to Disk
+
+### Prerequisites
+
+Verify you're in a git repo. If not, tell the user and stop.
+
+Verify that CLI tools for the detected ticket system are available. If not, tell the user what to install and stop.
+
+### Derive project identity
+
+Determine the project root path, project name (from the directory name), and a short hash of the root path to prevent collisions between repos with the same name. Use these to construct a unique `PROJECT_ID` in the form `<project-name>-<hash>` and a cache directory path in the system temp directory: `<temp>/architect-planner-<PROJECT_ID>`.
+
+### Destroy stale cache
+
+Remove the cache directory if it exists, then recreate it empty.
+
+### Parse time window (refine mode only)
+
+If the skill argument is `refine <duration>` (e.g., `refine 5h`), extract the duration and compute a cutoff ISO timestamp. The duration matches `^[0-9]+[mhd]$` (minutes, hours, or days). If no duration or invalid format, no cutoff is applied and refine targets all open tickets.
+
+### Cache tickets (two-tier)
+
+Using the detected ticket system's CLI tools, MCP tools, or APIs, fetch tickets in two tiers:
+
+**Open tickets (full detail):** Fetch all open tickets with full detail (ID, title, body/description, labels/tags, state, creation date, update date, comments, author, URL). When a time window is active (refine mode with duration), filter to only tickets created within the window. Write to `<cache>/issues-open.json`.
+
+If time-windowed refine returns zero results, tell the user and stop. Do not dispatch sub-agents.
+
+**Closed tickets (titles only):** Fetch recently closed tickets labeled `architecture` or `product` (titles, IDs, and labels only). Merge into a single deduplicated list. Write to `<cache>/issues-closed.json`.
+
+Normalize all fetched data into a consistent JSON shape regardless of the source platform.
+
+### Build the project map
+
+Explore the codebase and write a **project map** to `<cache>/project-map.md`. This is pointers and structure, NOT file contents. Sub-agents will read actual files themselves; the map just tells them what exists and where so they skip discovery.
+
+1. Read CLAUDE.md, README.md, and the dependency manifest (package.json / pyproject.toml / Cargo.toml / go.mod)
+2. Run a directory structure listing (pruned to reasonable depth, excluding .git and dependency directories)
+3. Identify entry points, key architectural files, and patterns (auth, validation, routing, database, config)
+4. Write the map
+
+The map should include:
+- **Tech stack**: language, framework, database, testing tools (extracted from dependency manifest)
+- **Directory structure**: actual tree output, pruned to reasonable depth
+- **Key files**: path + one-line description of what it does (entry points, middleware, routes, models, schemas, config)
+- **Architectural patterns**: how auth works, how errors are handled, how data flows (just name the files/patterns, don't explain the code)
+- **Conventions from CLAUDE.md**: note any project-specific conventions that affect auditing
+
+Keep the map factual and concise. No code snippets. No opinions. Just a guide to the terrain.
+
+### Assign tickets to clusters
+
+Each open ticket must be assigned to exactly one cluster to prevent multiple agents from editing the same ticket concurrently. This applies to both create and refine modes.
+
+1. Read `<cache>/issues-open.json`
+2. For each ticket, determine the single best-fit cluster based on its title, body, and labels
+3. Write per-cluster edit files (filtered subsets of the open tickets JSON):
+   - `<cache>/issues-edit-safety.json`
+   - `<cache>/issues-edit-correctness.json`
+   - `<cache>/issues-edit-maintainability.json`
+   - `<cache>/issues-edit-completeness.json`
+   - Empty clusters get an empty array
+
+4. Print the assignment table so the user can see it:
+
+```
+Ticket Assignment:
+  <id> "Ticket title..." -> Safety
+  <id> "Ticket title..." -> Correctness
+  ...
+```
+
+**Assignment rules:**
+- Every ticket gets assigned to exactly one cluster. No ticket is left unassigned.
+- Match by primary concern, not tangential relevance.
+- When a ticket spans multiple clusters, assign to the cluster that owns the root concern.
+- Tickets with no clear fit: assign to the cluster with the most overlapping focus areas.
+
+**Cluster slugs:** `safety`, `correctness`, `maintainability`, `completeness`
+
+## Step 2: Coverage Status
+
+Check the planner state file at `<temp>/planner-state/<PROJECT_ID>.json`. Create the directory and file if they don't exist.
+
+**You MUST print coverage status so the user knows when this was last run:**
+
+```
+Coverage Status (architect-planner):
+Last run: 2026-03-15 10:30
+Mode: create | refine | refine (last 5h, tickets since 2026-03-17T14:00:00Z)
+
+Clusters: Safety, Correctness, Maintainability, Completeness
+```
+
+Read the `architect-planner` value from the state file for the "Last run" timestamp. If null or missing, show "never". Show the active mode and, if time-windowed refine, the window and cutoff.
+
+## Step 3: Deploy Cluster Agents
+
+Spawn **4 sub-agents in parallel using the Agent tool**, one per cluster. **All 4 MUST be in a single message** so they run concurrently. Use `description: "Audit <ClusterName> cluster"` for each.
+
+For each cluster, construct a prompt by taking the Sub-Agent Prompt Template below and replacing:
+- `{MODE}` with `create` or `refine`
+- `{CACHE_DIR}` with the actual cache directory path
+- `{CLUSTER_NAME}`, `{CLUSTER_DESCRIPTION}`, `{FOCUS_TABLE}` with the cluster's content from Cluster Definitions
+- `{CLUSTER_SLUG}` with the cluster's slug from the assignment step
+- `{MODE_SECTION}` with the Full Mode or Refine Mode block from Mode-Specific Sections
+- `{TICKET_SYSTEM}` with the detected ticket system name
+
+---
+
+### Sub-Agent Prompt Template
+
+```
+You are a senior software architect auditing this codebase. You are one of 4 parallel agents, each focused on a different concern cluster.
+
+## Mode: {MODE}
+
+## Ticket System: {TICKET_SYSTEM}
+
+Use whatever CLI tools, MCP tools, or APIs are available to interact with the ticket system. Adapt commands to the platform (e.g., `gh issue create` for GitHub, `jira issue create` for Jira, `glab issue create` for GitLab, etc.).
+
+## Cached Tickets
+
+Do NOT fetch ticket lists yourself. Tickets are cached on disk.
+
+- `{CACHE_DIR}/issues-open.json` — all open tickets with full detail. **Read-only context** for awareness and cross-references.
+- `{CACHE_DIR}/issues-edit-{CLUSTER_SLUG}.json` — tickets assigned to YOUR cluster. You may ONLY modify tickets in this file.
+- `{CACHE_DIR}/issues-closed.json` — closed tickets with titles and labels only. Check this before filing new tickets to avoid duplicating something already resolved.
+
+**Edit constraint:** You may ONLY execute write commands (edit, close, create) against tickets in your edit file. For tickets outside your edit file, you have read-only access via `issues-open.json`. If you discover something relevant to a ticket outside your cluster, write it to your cross-cluster notes file at `{CACHE_DIR}/cross-cluster-{CLUSTER_SLUG}.json`. Do NOT add comments to any ticket.
+
+Use the labels/tags to distinguish ticket types. Tickets labeled `architecture` are yours; tickets labeled `product` are cross-reference. Tickets with neither label may need triage.
+
+Read every open ticket title in `issues-open.json`. Note which topics are covered.
+If a product ticket covers a related user-facing concern, don't duplicate. Reference it and focus on the technical root cause.
+
+## Cross-Cluster Notes
+
+If you discover a finding relevant to a ticket outside your edit file, write it to your cross-cluster notes file at `{CACHE_DIR}/cross-cluster-{CLUSTER_SLUG}.json`. Write a JSON array of objects:
+
+\`\`\`json
+[
+  {
+    "target_issue": 42,
+    "finding": "What you discovered, with file paths and evidence",
+    "related_issues": [15, 28]
+  }
+]
+\`\`\`
+
+If you have no cross-cluster findings, write an empty array: `[]`
+
+A post-processor will read your notes after all cluster agents finish and weave the findings into the target tickets' descriptions. Do not attempt to do this yourself.
+
+## Orient
+
+Start by reading the project map at `{CACHE_DIR}/project-map.md`. It tells you the tech stack, directory structure, key files, and architectural patterns. This replaces independent exploration. Do NOT run directory listings or search for entry points. The map has this.
+
+Then read the actual files relevant to your cluster directly from the project. The map tells you what exists; you read the code that matters for your focus areas.
+
+Critical mindset: Don't assume features are missing. Read the code. When you find existing implementations, evaluate: Is it robust? Edge cases? Bypassable? Fails safely?
+
+## Your Cluster: {CLUSTER_NAME}
+
+{CLUSTER_DESCRIPTION}
+
+{FOCUS_TABLE}
+
+Deep-read code for ALL focus areas in this cluster.
+
+Before assessing any file, check for recent activity:
+git log --since="3 days ago" --oneline -- <file>
+Note recent commits in tickets or skip if being addressed.
+
+## Synthesize Before Acting
+
+After reading all code for your cluster, stop. Before filing or refining any ticket, answer these questions about the code you just read:
+
+1. **Why was it built this way?** Understand the original author's intent and constraints before judging. Code that survived production earned its place. What problem was it solving?
+2. **Where does the architecture fight the problem?** Complexity that doesn't serve the domain, missing abstractions that would improve testability or clarity, over-abstraction that obscures intent without enabling anything.
+3. **Where is logic fragmented?** The same concern scattered across files that should be consolidated, or a monolith that should be decomposed for testability and clarity.
+4. **What would the right architecture look like?** Not necessarily simpler. The architecture that best fits the problem. Sometimes that means adding a proper abstraction layer, an interface for mockability, or a separation that enables independent testing. Sometimes it means consolidating.
+
+When multiple surface-level findings (a race condition here, missing validation there, inconsistent errors elsewhere) trace back to the same architectural root cause, **the root cause is your ticket**, not the individual symptoms.
+
+{MODE_SECTION}
+
+## Stay In Your Lane
+
+File about: Bugs, security, error handling, race conditions, architecture, DRY violations, naming inconsistencies, dead code, type safety gaps, API contract issues, incomplete implementations, performance, test gaps, data integrity
+NOT about: UX, user confusion, missing features, terminology, onboarding, accessibility
+```
+
+---
+
+### Cluster Definitions
+
+**Safety** - Boundaries and defenses. What happens when bad input arrives, auth is missing, errors occur, or systems go down?
+
+| Focus Area | What to Look For |
+|------------|-----------------|
+| **Input validation** | Unsanitized user input, missing schema checks at boundaries, SQL injection, XSS vectors |
+| **Auth & secrets** | Auth bypass paths, tokens in logs/URLs, secrets in code, missing middleware on routes |
+| **Error handling** | Unhandled promise rejections, empty catch blocks, silent failures, missing error propagation |
+| **Failure modes** | What happens when DB is down? API timeout? Network partition? Graceful degradation vs. silent corruption |
+
+**Correctness** - Does the code do what it claims? Concurrency bugs, logic errors, type holes, data corruption paths.
+
+| Focus Area | What to Look For |
+|------------|-----------------|
+| **Race conditions** | Concurrent writes without locks, TOCTOU bugs, missing transactions, unsafe shared state |
+| **Logical flow** | Unreachable code, impossible states, off-by-one errors, wrong operator, inverted conditions |
+| **Type safety** | `any` types, missing type annotations on public interfaces, unsafe casts/assertions that suppress real errors, runtime type mismatches that static analysis misses |
+| **Data integrity** | Missing foreign keys, orphaned records, no cascading deletes, inconsistent state possible |
+
+**Maintainability** - Can the next developer understand and safely change this? Cruft, duplication, misleading names, structural problems.
+
+| Focus Area | What to Look For |
+|------------|-----------------|
+| **Dead code** | Unused functions, unreachable branches, imports that go nowhere, feature flags permanently on/off, commented-out code left behind, variables assigned but never read |
+| **DRY & code reuse** | Duplicated logic across files (same validation, same transformation, same API call pattern in 2+ places), copy-pasted components or controls that should be shared, near-identical functions that differ only in a parameter, opportunities to extract shared utilities or composables |
+| **Naming & semantics** | Misleading function/variable/file names, names that don't match what the code actually does, inconsistent naming for the same concept across files (e.g., `user` in one file and `account` in another for the same entity), abbreviations that obscure meaning, boolean names that read backwards |
+| **Architecture & file organization** | God files (split when a file serves multiple unrelated purposes), missing abstractions, directory structure that doesn't reflect domain boundaries, files in the wrong directory for what they do |
+
+**Completeness** - Is the work finished? Missing tests, inconsistent APIs, unused config, unhandled branches, performance gaps.
+
+| Focus Area | What to Look For |
+|------------|-----------------|
+| **API contract consistency** | Endpoints returning different response shapes for similar resources, inconsistent error formats across endpoints, fields present in one response but missing from a sibling endpoint |
+| **Configuration hygiene** | Hardcoded magic numbers/strings that should be config, config values defined but never read, env vars documented but unused (or used but undocumented) |
+| **Consistency & completeness** | A pattern used in N places but missing from the N+1th, partial migrations (old approach in some files, new approach in others), enum values or config options that exist in a definition but aren't handled in all switch/if branches, features half-wired (route exists but component doesn't use it, field added to model but never populated) |
+| **Test coverage** | Untested critical paths, missing edge case tests, no integration tests for key flows |
+| **Performance** | N+1 queries, missing indexes, unbounded loops, memory leaks, missing pagination |
+
+---
+
+### Mode-Specific Sections
+
+**Create mode** (no argument or `create`), insert as `{MODE_SECTION}`:
+
+```
+## Create New Tickets
+
+Your job: find NEW problems in the codebase within your cluster's focus areas and file well-formed tickets.
+
+Hard cap: maximum 3 new tickets.
+
+### Dedup Check
+
+Before creating any ticket, scan existing tickets for overlap:
+1. Read ticket titles and descriptions in issues-open.json. Is this problem already covered?
+2. Check issues-closed.json titles. Was this already filed and resolved?
+3. If already covered and your finding adds context: if the ticket is in your edit file, edit the description directly. If it is outside your edit file, write it to your cross-cluster notes file. Do NOT add comments. Do NOT rewrite existing ticket descriptions, that's refine's job.
+4. If not covered: create a new focused ticket.
+
+If you notice an existing ticket has obviously wrong info (e.g., references a file that no longer exists, wrong label), fix it. But do NOT deeply scrutinize, rewrite descriptions, or re-evaluate severity, that's refine's job.
+
+### Pre-Filing Gate
+
+Before filing, ask: "So what, and is the fix worth the trade-off?" If the system already handles the outcome (negative balances by design, proxy handles security headers, parameterized queries make "unvalidated" input safe), there's no issue. If the fix adds complexity for marginal benefit, the cure is worse than the disease. A theoretical race condition whose consequence is already handled gracefully isn't a real problem.
+
+### Filing
+
+Create a new ticket with the `architecture` label and a severity label (`severity:high`, `severity:medium`, or `severity:low`). Use the following structure for the body:
+
+## Problem
+What is wrong or missing. Reference specific files and line numbers.
+
+## Root Cause
+Why this problem exists. The architectural decision, structural pattern, or missing abstraction that produced it. If multiple symptoms share this root cause, name them. Don't just describe the symptom; explain what about the current architecture allowed or caused it.
+
+## Evidence
+Code snippet or trace showing the issue. Not speculation, proof.
+
+## Risk
+What can go wrong. Severity (data loss? security breach? silent corruption? annoying log noise?).
+
+## Suggested Fix
+Describe the target architecture. What the code should look like after, not just what to change. Explain why this structure fits the problem (testability, performance, maintainability, clarity). One confident direction, not a menu of options.
+
+Severity guide:
+- severity:high: Data loss, security breach, silent corruption, or production outage possible
+- severity:medium: Incorrect behavior under edge cases, degraded reliability, or maintainability hazard
+- severity:low: Code smell, minor inconsistency, theoretical concern unlikely to bite
+
+Rules:
+- One problem per ticket
+- Label all tickets architecture + a severity label
+- Never file UX complaints, copy issues, or product gaps
+- Reference specific files and line numbers you actually read
+- Distinguish "missing entirely" from "exists but has gaps"
+- For security issues, note external vs internal exploitability
+```
+
+**Refine mode** (`refine` or `refine <duration>`), insert as `{MODE_SECTION}`:
+
+```
+## Refine Existing Tickets
+
+Your job: improve existing tickets related to your cluster. Do NOT create new tickets.
+
+Prioritize:
+1. Open tickets related to your cluster's focus areas
+2. Oldest open tickets without recent comments
+3. Tickets related to code you just read
+
+For each ticket you deep-read, ask:
+- Still true? Read the code NOW. Close with evidence if fixed.
+- Analysis correct? If wrong, rewrite the description with corrected analysis.
+- Symptom or root cause? Trace the problem upstream. If the ticket describes a symptom, rewrite it to address the architectural root cause. If multiple open tickets share a root cause, consolidate into one architectural ticket and close the others with a cross-reference.
+- Complete? Add line numbers, code paths, edge cases to the description.
+- Fix sound? The suggested fix should describe the target architecture, why this structure fits the problem, not just a patch. Update if it's vague, offers multiple options, or only addresses the symptom.
+- Severity right? Recalibrate and update the severity label.
+- Dependencies? If the dependency is in your edit file, add cross-references to the description. If outside your edit file, write to your cross-cluster notes file.
+
+### Editing tickets: description is the source of truth
+
+**When the ticket's core content needs changing** (problem statement, evidence, severity, fix direction), **edit the description directly**. The description must always be the canonical, accurate statement. Do NOT leave corrections as comments while the description stays wrong.
+
+**When synthesizing:** If the ticket has comments from the same user as you (prior skill runs), fold their corrections and additions into the description, then delete those comments. The description becomes one clean, authoritative ticket. Never touch comments from other users.
+
+Do not add comments to any ticket. All findings, cross-references, and dependency notes belong in the ticket description. If the target ticket is in your edit file, edit the description directly. If it is outside your edit file, write to your cross-cluster notes file.
+
+### Available operations
+
+Ticket bodies and comments are already in issues-open.json, no need to fetch them again.
+
+- Edit a ticket's description
+- Delete a redundant comment from a prior skill run (after synthesizing into description)
+- Close a resolved ticket (add a Resolution section to the description first, then close)
+
+Use whatever CLI tools or APIs are available for the detected ticket system.
+
+Do not rubber-stamp. If something feels off, dig in.
+```
+
+---
+
+## Step 3.5: Post-Process Cross-Cluster Notes
+
+After all 4 sub-agents complete, check for cross-cluster findings:
+
+1. Read all cross-cluster note files from the cache directory:
+   - `cross-cluster-safety.json`
+   - `cross-cluster-correctness.json`
+   - `cross-cluster-maintainability.json`
+   - `cross-cluster-completeness.json`
+
+2. Collect all notes into a single list. If every file is an empty array or missing, skip to Step 4.
+
+3. If there are notes, spawn a single **foreground** post-processor agent with the collected notes **inlined in the prompt** (not as file paths, since the cache will be cleaned after).
+
+### Post-Processor Agent Prompt
+
+```
+You are a post-processor for the architect-planner. Parallel cluster agents have completed their work and left cross-cluster findings that need to be woven into ticket descriptions. Your job is to incorporate each finding into the target ticket's description.
+
+## Ticket System: {TICKET_SYSTEM}
+
+Use whatever CLI tools, MCP tools, or APIs are available to interact with the ticket system.
+
+## Rules
+
+- Process one ticket at a time, sequentially
+- For each target ticket: read the current description, then edit it to incorporate the finding
+- Weave findings into the appropriate existing section of the description. Do not append a generic "Cross-Cluster Findings" section. Use editorial judgment to place the finding where it belongs contextually.
+- If a finding is a simple cross-reference ("Related to <id>"), add it inline near the relevant content in the description
+- If a finding adds substantive analysis, integrate it into the relevant section (Problem, Root Cause, Evidence, Risk, Suggested Fix, etc.)
+- Do NOT create new tickets, close tickets, or add comments
+- Do NOT change content that was already in the description, only add the new findings
+
+## Cross-Cluster Findings
+
+{COLLECTED_NOTES_JSON}
+```
+
+---
+
+## Step 4: Cleanup & Update State
+
+After all sub-agents and post-processing complete:
+
+**Delete the cache directory and verify it's gone.** If cleanup fails, do NOT proceed. Investigate and retry. Stale cache left behind will corrupt the next run.
+
+**Update the state file** at `<temp>/planner-state/<PROJECT_ID>.json`. Read the existing JSON, set `architect-planner` to the current ISO timestamp (e.g., `2026-03-15T10:30:00`). Write back. Preserve any existing `product-planner` data.

--- a/skills/convert-worktree
+++ b/skills/convert-worktree
@@ -1,1 +1,0 @@
-/Users/adam/.claude/skills/convert-worktree

--- a/skills/convert-worktree/SKILL.md
+++ b/skills/convert-worktree/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: convert-worktree
+description: Convert a git worktree into a local branch — rebase onto latest main, clean up project resources, remove worktree, checkout branch in main workspace. Use when finishing work in a worktree.
+disable-model-invocation: true
+---
+
+# Convert Worktree
+
+Convert a git worktree into a regular local branch. Rebases onto the latest base branch, runs project cleanup, removes the worktree, and checks out the branch in the main workspace.
+
+This skill replaces ExitWorktree — do not call ExitWorktree after this skill runs.
+
+## Steps
+
+### 1. Verify context
+
+Run these checks. Fail fast if any fail.
+
+```bash
+# Get main worktree path
+MAIN_WORKTREE=$(git worktree list --porcelain 2>/dev/null | head -1 | sed 's/worktree //')
+
+# Confirm we're in a worktree (current dir differs from main worktree)
+if [ "$MAIN_WORKTREE" = "$(pwd)" ] || [ -z "$MAIN_WORKTREE" ]; then
+  # FAIL: "Not in a worktree. This skill only works from inside a worktree."
+fi
+
+# Confirm not detached HEAD
+BRANCH=$(git branch --show-current)
+if [ -z "$BRANCH" ]; then
+  # FAIL: "Detached HEAD — nothing to convert. Checkout a branch first."
+fi
+
+WORKTREE_PATH=$(pwd)
+```
+
+Detect the base branch dynamically:
+```bash
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+# Fall back to main, then master
+if [ -z "$BASE_BRANCH" ]; then
+  git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+fi
+```
+
+Announce: "Converting worktree `<WORKTREE_PATH>` (branch `<BRANCH>`) → main workspace at `<MAIN_WORKTREE>`"
+
+### 2. Commit uncommitted work
+
+```bash
+# Check for any changes (staged, unstaged, or untracked)
+if [ -n "$(git status --porcelain)" ]; then
+  git add -A
+  git commit -m "wip: uncommitted changes from worktree conversion"
+fi
+```
+
+`.gitignore` handles exclusions so `git add -A` is safe.
+
+### 3. Project cleanup
+
+Run while still in the worktree so project-specific variables (DB names, ports) resolve correctly.
+
+```bash
+# Convention-based: if Makefile has dev-stop, run it
+if [ -f Makefile ] && grep -q '^dev-stop:' Makefile; then
+  make dev-stop || echo "Warning: make dev-stop failed, continuing"
+fi
+```
+
+Cleanup failure must not block the conversion.
+
+### 4. Rebase onto latest base branch
+
+```bash
+# Fetch latest (skip if no origin remote)
+git fetch origin "$BASE_BRANCH" 2>/dev/null || true
+
+# Determine rebase target
+if git rev-parse --verify "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+  REBASE_TARGET="origin/$BASE_BRANCH"
+else
+  REBASE_TARGET="$BASE_BRANCH"
+fi
+
+# Check if already up-to-date
+if git merge-base --is-ancestor "$REBASE_TARGET" HEAD 2>/dev/null; then
+  # Already up-to-date, skip rebase
+fi
+```
+
+Run rebase. Handle conflicts:
+
+- **Lockfiles** (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Cargo.lock`, `go.sum`): accept theirs and stage:
+  ```bash
+  git checkout --theirs <lockfile>
+  git add <lockfile>
+  git rebase --continue
+  ```
+  Note: lockfile will be slightly stale. Remind user to run `npm install` (or equivalent) after checkout.
+
+- **Code conflicts**: if rebase hits a conflict that isn't a lockfile, abort immediately:
+  ```bash
+  git rebase --abort
+  ```
+  Warn the user that the branch is un-rebased. Continue with the rest of the conversion.
+
+Never block the conversion on rebase failure.
+
+### 5. Remove worktree, checkout branch in main workspace
+
+```bash
+# Check main workspace is clean before attempting checkout
+cd "$MAIN_WORKTREE"
+if [ -n "$(git status --porcelain)" ]; then
+  # WARN: "Main workspace has uncommitted changes. Checkout may fail."
+  # Ask user: proceed or abort?
+fi
+
+git worktree remove "$WORKTREE_PATH" --force
+git checkout "$BRANCH"
+```
+
+### 6. Report
+
+Print a summary:
+
+```
+Branch <BRANCH> checked out in <MAIN_WORKTREE>
+  Rebase: <succeeded | skipped (already up-to-date) | failed (branch is un-rebased)>
+  Cleanup: <ran make dev-stop | no cleanup target found | cleanup failed>
+  <If lockfiles were auto-resolved: "Run npm install (or equivalent) to update lockfiles">
+```
+
+## Rules
+
+- **Never block on failure.** Rebase failure, cleanup failure, and lockfile conflicts are all warnings. The conversion always completes.
+- **Never push, create PRs, delete branches, or merge.** Those are separate user decisions.
+- **Cleanup before rebase.** Project cleanup needs worktree context (variables, paths). Rebase happens after.
+- **Always use `git add -A` for WIP commits.** New untracked files are common in worktrees. `.gitignore` handles exclusions.
+- **Detect the base branch dynamically.** Don't hardcode `main` — check `git symbolic-ref refs/remotes/origin/HEAD`, fall back to `main`, then `master`.
+- If on main/master or not in a worktree, warn and stop.

--- a/skills/get-it-right
+++ b/skills/get-it-right
@@ -1,1 +1,0 @@
-/Users/adam/.claude/skills/get-it-right

--- a/skills/get-it-right/SKILL.md
+++ b/skills/get-it-right/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: get-it-right
+description: Use when work on a branch is complete or in-progress and you want to re-evaluate the approach from scratch — performs retrospective analysis, re-architects to reduce complexity and fragmentation, auto-implements without committing, and outputs a brief testing playbook for validation
+---
+
+# Get It Right
+
+Re-architect the current branch's work as if starting from scratch. Reduce complexity, consolidate fragmentation, auto-implement, and hand the user a brief testing playbook.
+
+## Workflow
+
+```dot
+digraph get_it_right {
+    rankdir=TB;
+    "Identify scope" -> "Deep-read implementation";
+    "Deep-read implementation" -> "Retrospective analysis";
+    "Retrospective analysis" -> "Plan re-architecture";
+    "Plan re-architecture" -> "Auto-implement (no commit)";
+    "Auto-implement (no commit)" -> "Format + lint + test";
+    "Format + lint + test" -> "Output testing playbook";
+}
+```
+
+### 1. Identify Scope
+
+Determine what work is being done on the current branch:
+- `git log main..HEAD --oneline` — all commits on this branch
+- `git diff main...HEAD --stat` — all changed files
+- If issue number is in branch name, read the GitHub issue for original intent
+
+### 2. Deep-Read Current Implementation
+
+Read every changed and related file in full (not just diffs):
+- `git diff main...HEAD` — the full diff
+- Read each changed file end-to-end to understand surrounding context
+- Trace dependencies: what else calls, imports, or is affected by these files?
+- Map the architecture: where does logic live, how does data flow?
+
+### 3. Retrospective Analysis
+
+Answer these questions explicitly in your output before planning:
+
+1. **What should we have done before starting?** Prerequisites, research, preparatory refactors that would have made this cleaner.
+2. **Where is complexity unnecessary?** Abstractions that don't earn their keep, indirection that obscures intent, over-engineering.
+3. **Where is the fragmentation?** Logic split across too many files, repeated patterns that should be shared, inconsistent approaches to the same problem.
+4. **What would change if starting fresh?** File organization, function boundaries, data flow, naming, API surface.
+5. **What's the simplest version that works?** Strip accidental complexity. What's the minimum architecture?
+
+Present one confident recommendation. Do not present options A/B/C.
+
+### 4. Plan the Re-architecture
+
+Enter plan mode. The plan must:
+- State what changes and why (retrospective insights drive the plan)
+- Specify exact files to modify, create, or delete
+- Order steps to minimize broken intermediate states
+- Target reduced file count, reduced indirection, consolidated logic
+- Preserve all existing behavior (re-architecture, not behavior change)
+
+### 5. Auto-Implement
+
+Execute the plan without user interaction:
+- Make all changes across the codebase
+- Run format and lint (check CLAUDE.md for project commands)
+- Run tests (check CLAUDE.md for project test commands)
+- Fix any failures from format/lint/tests
+- **Do NOT commit** — leave all changes unstaged for user review
+
+### 6. Output Testing Playbook
+
+After implementation, output a brief playbook the user follows in the running app:
+- Just the key scenarios to validate: happy path, primary edge case, primary error case
+- Be specific: what to do, what to expect
+- Keep it short — 3-6 items max, not an exhaustive checklist
+
+## Key Principles
+
+- **The current implementation is your teacher.** Understand why it was built this way before changing it.
+- **Fewer files > more files.** Consolidate unless separation of concerns demands otherwise.
+- **Fewer abstractions > more abstractions.** Every indirection layer must earn its keep.
+- **Tests are the constraint.** All existing behavior must be preserved. Tests must pass.
+- **Don't commit.** The user reviews everything before any git operations.
+- **Don't ask.** Auto-implement unaided. The testing playbook is how the user validates.

--- a/skills/next-ticket
+++ b/skills/next-ticket
@@ -1,1 +1,0 @@
-/Users/adam/.claude/skills/next-ticket

--- a/skills/next-ticket/SKILL.md
+++ b/skills/next-ticket/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: next-ticket
+description: Use when looking for the next ticket to work on. Detects the project's ticket system (GitHub Issues, Jira, GitLab Issues, Azure Boards, etc.), fetches all open tickets, scores by severity/simplicity/value/blocking-power/dependencies, picks the best candidate, branches, implements, tests, formats, and waits for review with a UI testing tip.
+---
+
+# Next Ticket
+
+Pick the highest-value open ticket, implement it end-to-end, and wait for review.
+
+## Prerequisites
+
+Verify you're in a git repo before starting. If not, tell the user and stop.
+
+## Step 1: Detect Ticket System
+
+Determine which ticket system this project uses. Check in this order:
+
+1. **Cached config**: Check for a `next-ticket-config.json` file in the system temp directory. It maps project root paths to ticket system names. If the current project has an entry, use that value.
+2. **Auto-detect**: Run `git remote -v` and interpret the host to determine the likely ticket system (e.g., github.com suggests GitHub Issues, bitbucket.org suggests Jira, gitlab.com suggests GitLab Issues, dev.azure.com or visualstudio.com suggests Azure Boards).
+3. **Ask the user**: If auto-detect fails, ask: "What ticket system does this project use?" Accept a free-form answer (e.g., "jira", "github issues", "linear", "shortcut").
+
+Once determined, cache the value in `next-ticket-config.json` in the system temp directory, keyed by project root path. Create the file if it doesn't exist. Merge with existing entries if it does.
+
+Confirm the detected system to the user (e.g., "Detected ticket system: GitHub Issues"). If the user corrects it, update the cached value and proceed with their answer.
+
+> **Tip**: If auto-detect consistently gets it wrong for a project (e.g., a GitHub-hosted repo that uses Jira), add `ticketSystem: jira` to the project's CLAUDE.md to skip detection.
+
+## Step 2: Fetch All Open Tickets
+
+Using whatever CLI tools, MCP tools, or APIs are available in the current session, fetch all open tickets from the detected system.
+
+**Common tools by platform:**
+- GitHub Issues: `gh issue list`
+- Jira: `jira` CLI, Atlassian MCP tools, or REST API via `curl`
+- GitLab Issues: `glab issue list`
+- Azure Boards: `az boards work-item list`
+- Other: Use whatever is available. If no tool is found, tell the user what to install and stop.
+
+Normalize the fetched data into this shape (write to a temp file):
+
+```json
+[
+  {
+    "id": "42",
+    "title": "Fix auth token refresh race condition",
+    "body": "Full description...",
+    "labels": ["bug", "severity:high"],
+    "assignees": [],
+    "created_at": "2025-01-15T10:00:00Z",
+    "comments": []
+  }
+]
+```
+
+Also fetch recently closed/resolved tickets (titles and IDs only) to understand what's already been done.
+
+If zero open tickets, tell the user and stop.
+
+## Step 3: Score and Rank
+
+Read every ticket's title, full body, labels, and comments. Build a mental scorecard for each ticket using these factors:
+
+### Scoring Factors
+
+| Factor | Weight | How to Assess |
+|--------|--------|---------------|
+| **Severity** | High | Read severity labels or priority fields. No label = medium. |
+| **Simplicity** | High | From the description and suggested fix: is this a focused, well-scoped change? Prefer tickets where the fix is clear and contained over vague or sprawling ones. |
+| **Blocking power** | High | Does this ticket's body or comments mention it blocks other tickets? Are other tickets referencing this one as a dependency? Prefer prereqs. |
+| **Value** | Medium | Is this foundational (auth, data model, core flow)? Or cosmetic? Foundational work compounds. |
+| **Dependencies** | Eliminates | If the ticket explicitly depends on another open ticket, skip it. |
+| **Assignee** | Eliminates | If already assigned to someone, skip it. |
+| **Age** | Low | Older tickets are slightly preferred (avoid starvation). |
+| **Clarity** | Medium | Is the problem well-defined with evidence and a suggested fix? Vague tickets are riskier for AFK implementation. |
+
+### Decision Process
+
+1. **Eliminate** tickets that have unmet dependencies on other open tickets, or are assigned.
+2. **Rank** remaining tickets. Severity and simplicity dominate. Blocking power breaks ties.
+3. **Pick the top candidate.** If two tickets are very close, prefer the simpler one (higher confidence of correct AFK implementation).
+
+### Announce Selection
+
+Print a brief rationale, formatting the ticket ID according to the platform (e.g., `#42` for GitHub/GitLab, `PROJ-42` for Jira, `42` for Azure Boards):
+
+```
+Selected: <ticket-id> - "Fix auth token refresh race condition"
+  Severity: high | Simplicity: focused (single file) | Blocks: <id>, <id>
+  Reason: Highest severity, clear fix direction, unblocks two other tickets.
+```
+
+## Step 4: Validate Against Current Code
+
+Before branching, verify the selected ticket is still valid on the latest codebase.
+
+1. **Locate the relevant code.** Use the ticket body, referenced files, error messages, and stack traces to find the code in question. If the ticket references files or functions that no longer exist, the ticket may be stale.
+2. **Check for prior fixes.** Search git log for commits referencing the ticket ID. Look for evidence of prior work on this ticket.
+3. **Reproduce the problem.** Attempt to confirm the ticket is still valid:
+   - **Bugs**: Read the relevant code paths. Is the described bug still present in the logic?
+   - **Features**: Is the requested functionality already implemented?
+   - **Refactors/chores**: Is the target code still in the state described?
+4. **Verdict:**
+   - **Still valid**: proceed to Step 5.
+   - **100% resolved**: All items in the ticket are addressed. Mark as resolved with a comment explaining what you found, then loop back to Step 3 and pick the next candidate.
+   - **Partially resolved**: Some items remain. You have two options:
+     - **Work on it**: If the remaining work is a good candidate (simple, high-value), proceed to Step 5.
+     - **Refine and skip**: If you'd rather pick a different ticket, do NOT close this one. Instead, edit the ticket body to remove completed items (keep only remaining work), update the title to reflect the narrower scope, add a comment summarizing what was already done, then loop back to Step 3. The refined ticket becomes eligible for future iterations.
+   - **Can't determine**: proceed with caution and note uncertainty.
+
+## Step 5: Create Branch
+
+Determine the branch category from the ticket content:
+- Bug/defect/error/crash/race condition/fix = `fix/`
+- New feature/add/create/implement = `feat/`
+- Refactor/rename/restructure/clean up = `refactor/`
+- Documentation = `docs/`
+- Everything else = `chore/`
+
+Ensure you're on the latest default branch (typically `main` or `master`), then create a new branch following the naming convention `<category>/<ticket-id>-<brief-desc>` (e.g., `fix/42-auth-token-refresh-race`). Keep the description part to 3-5 hyphenated words derived from the ticket title.
+
+## Step 6: Write Failing Tests (TDD)
+
+**Tests come first.** The ticket body is your spec. Translate it into concrete test assertions before writing any implementation code.
+
+1. **Explore**: Read the files referenced in the ticket. Understand the existing code, test patterns, framework, file naming, and style before writing anything.
+2. **Derive the contract**: From the ticket body, identify the specific behaviors that should change or be added. What should be true when this ticket is resolved?
+3. **Write tests that assert the desired behavior.** Match the project's existing test patterns exactly.
+   - **Bugs**: Write a test that reproduces the bug. It should fail now and pass after the fix. The test asserts the *correct* behavior, not the buggy behavior.
+   - **Features**: Write tests for the new functionality's expected inputs, outputs, and edge cases.
+   - **Refactors**: Skip this step. Refactors should not change behavior. Proceed to Step 7.
+   - **Docs/chores**: Skip this step. Proceed to Step 7.
+4. **Run the new tests and confirm they fail.** If they pass already, the ticket may be resolved. Loop back to Step 4 to re-validate; it will handle the verdict. If they fail for the wrong reason (e.g., import error, syntax), fix the test before proceeding.
+
+**Do not write implementation code until you have failing tests that represent the ticket's contract.**
+
+## Step 7: Implement Until Green
+
+1. **Implement**: Write the minimum code to make the failing tests pass. Follow existing code patterns and conventions. Respect CLAUDE.md rules.
+2. **Run your new tests.** Iterate until they pass.
+3. **Run the full test suite** to ensure nothing else broke. Use the project's test runner (e.g., `make test`, `npm test`, `pytest`, `go test ./...`, `cargo test`).
+4. **Keep it focused**: Only change what the ticket requires. Don't refactor unrelated code, add unrequested features, or "improve" surrounding code.
+
+If a pre-existing test fails:
+- If your change broke it: fix your implementation to not break it, or update the test if your change intentionally changes behavior.
+- If it's a pre-existing flaky test unrelated to your changes: note it and move on.
+
+If the ticket is unclear or the fix direction is ambiguous, make the most reasonable interpretation and note your assumptions in the commit message.
+
+**Do not proceed until all tests pass, both yours and pre-existing.**
+
+## Step 8: Format
+
+Run the project's formatter (e.g., `make nice`, `npm run format`, `cargo fmt`, `go fmt ./...`, `black .`). If it modifies files, that's expected. If it fails, investigate and fix.
+
+## Step 9: Commit
+
+Stage and commit all changes with a descriptive message referencing the ticket. Use whatever closing syntax the platform recognizes for auto-closing tickets from commits (e.g., `Closes #42` for GitHub, `Resolves PROJ-42` for Jira).
+
+Do NOT push. Do NOT create a PR. Wait for the user.
+
+## Step 10: Wait for Review
+
+Print a brief summary:
+
+```
+Done. Ready for review.
+
+Branch: <branch-name>
+Ticket: <ticket-id> - <ticket title>
+Files:  <list changed files>
+
+To test in the UI: <one sentence describing the specific UI action that exercises this change>
+```
+
+The UI testing tip must be **specific and actionable**, not "test the feature" but "log in, wait 15 minutes for the token to expire, then click any nav link, it should refresh silently instead of kicking you to login."
+
+## Rules
+
+- **Never push or create PRs.** The user reviews first.
+- **Never skip tests.** AFK implementation demands high confidence.
+- **Never pick an assigned ticket.** Someone else is working on it.
+- **Never pick a ticket with unmet dependencies.** It can't be completed.
+- **Validation (Step 4): refine, don't close.** If a ticket has remaining work, edit the ticket to reflect only what remains (update title and body), then move to the next candidate. Never close a ticket that isn't 100% resolved.
+- **Implementation (Steps 5-9): fully implement.** Once you pick a ticket, complete it entirely. No partial commits, no WIP commits, no handoffs. The scoring in Step 3 filters for simplicity and clarity precisely so that picked tickets can be fully implemented touch-free.
+- **If no suitable ticket exists** (all assigned, all blocked, none clear enough for AFK), tell the user and stop.
+- **Clean up temp files** when done.

--- a/skills/pr
+++ b/skills/pr
@@ -1,1 +1,0 @@
-/Users/adam/.claude/skills/pr

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: pr
+description: Format, lint, test, commit, push, and create a pull request — the single "I'm done" command.
+---
+
+# PR — Format, Lint, Test, Commit, Push, Create Pull Request
+
+Single command to go from "I'm done" to "PR is open."
+
+## Workflow
+
+1. **Verify not on main**: Check current branch with `git branch --show-current`
+   - If on `main` or `master`, stop and tell user to create a feature branch first
+
+2. **Format and lint** (check CLAUDE.md for the project's commands):
+   - **Skip if** passing output is visible in this conversation and no files changed since. Cite the prior result.
+   - If it fails, report errors and stop
+
+3. **Run tests** (check CLAUDE.md for the project's test command):
+   - **Skip if** passing output is visible in this conversation and no files changed since. Cite the prior result.
+   - If tests fail, report failures and stop
+
+4. **Stage and commit auto-fixed files**:
+   - Check `git status` for changes from formatting
+   - If there are changes: stage them, commit with message "Auto-format and lint fixes"
+   - If no changes: skip
+
+5. **Push to remote**:
+   - Check if branch exists on remote: `git ls-remote --heads origin $(git branch --show-current)`
+   - If new branch: `git push -u origin $(git branch --show-current)`
+   - If existing: `git push`
+   - If already up-to-date: skip
+
+6. **Extract issue number from branch name**:
+   - Pattern: `<category>/<number>-<desc>` → `#<number>`
+   - Example: `fix/224-streaming-upload-size-check` → `224`
+   - If no number found: warn "No issue number found in branch name — add Closes #NNN manually if applicable"
+
+7. **Create or update PR**:
+   - Check if PR exists: `gh pr view --json number,url 2>/dev/null`
+   - If PR exists: show URL, say "PR updated with latest changes"
+   - If no PR exists:
+     - Analyze `git diff main...HEAD` and `git log main..HEAD --oneline` to understand scope
+     - Create PR with `gh pr create`:
+       - Concise title (under 70 chars, conventional commit style)
+       - Body:
+         ```
+         ## Summary
+         <3-5 bullet points on what and why>
+
+         ## Changes
+         <Key technical changes as bullet list>
+
+         ## Testing
+         <What was tested locally>
+
+         Closes #<number>
+
+         Generated with [Claude Code](https://claude.com/claude-code)
+         ```
+   - Return PR URL to user
+
+## Error Handling
+
+- **On main branch**: Stop immediately, suggest creating feature branch
+- **No changes AND no commits ahead of main**: Inform user there's nothing to PR
+- **Format/lint fails**: Stop, show errors — cannot push unlinted code
+- **Tests fail**: Stop, show failures — cannot push broken code
+- **Push rejected (behind remote)**: Suggest `git pull --rebase origin <branch>`
+- **`gh` not authenticated**: Detect with `gh auth status`, show clear error
+- **No issue number in branch**: Warn but continue — don't block the PR
+
+## Usage
+
+```bash
+# The only command you need
+/pr
+
+# Typical workflow:
+# 1. Make changes on feature branch
+# 2. /pr (does everything: format, lint, test, commit, push, PR)
+# 3. Review PR in GitHub
+```

--- a/skills/product-planner
+++ b/skills/product-planner
@@ -1,1 +1,0 @@
-/Users/adam/.claude/skills/product-planner

--- a/skills/product-planner/SKILL.md
+++ b/skills/product-planner/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: product-planner
+description: Audits a project for UX gaps, broken workflows, missing states, confusing terminology, visual inconsistency, navigation/state issues, destructive action safety, data presentation, accessibility issues, and competitive table stakes. Caches tickets to disk, then spawns 4 parallel sub-agents (one per focus cluster) to scrutinize and file tickets.
+argument-hint: "[create | refine [<duration>]]"
+---
+
+# Product Planner
+
+You are an **orchestrator**. You do NOT audit the product yourself. Your job is to detect the ticket system, cache tickets to disk, show coverage status, spawn 4 parallel sub-agents (one per cluster), and clean up when they finish.
+
+## Mode
+
+Check the argument passed to this skill:
+- **No argument or `create`**: Create mode, sub-agents read code, check existing tickets for dupes, and file new tickets. They do NOT deeply scrutinize or rewrite existing tickets (only fix links, labels, or obviously wrong info).
+- **`refine`**: Refine mode, sub-agents scrutinize, improve, correct, and close existing tickets but **create ZERO new tickets**
+- **`refine <duration>`**: Time-windowed refine, same as refine but only tickets created within the window (e.g., `5h`, `10m`, `6d`)
+
+Usage: `/product-planner`, `/product-planner refine`, or `/product-planner refine 5h`
+
+## Step 0: Detect Ticket System
+
+Determine which ticket system this project uses. Check in this order:
+
+1. **Cached config**: Check for a `next-ticket-config.json` file in the system temp directory. It maps project root paths to ticket system names. If the current project has an entry, use that value.
+2. **Auto-detect**: Run `git remote -v` and interpret the host to determine the likely ticket system (e.g., github.com suggests GitHub Issues, bitbucket.org suggests Jira, gitlab.com suggests GitLab Issues, dev.azure.com or visualstudio.com suggests Azure Boards).
+3. **Ask the user**: If auto-detect fails, ask: "What ticket system does this project use?" Accept a free-form answer (e.g., "jira", "github issues", "linear", "shortcut").
+
+Once determined, cache the value in `next-ticket-config.json` in the system temp directory, keyed by project root path. Create the file if it doesn't exist. Merge with existing entries if it does.
+
+Confirm the detected system to the user (e.g., "Detected ticket system: GitHub Issues"). If the user corrects it, update the cached value and proceed with their answer.
+
+> **Tip**: If auto-detect consistently gets it wrong for a project (e.g., a GitHub-hosted repo that uses Jira), add `ticketSystem: jira` to the project's CLAUDE.md to skip detection.
+
+## Step 1: Cache to Disk
+
+### Prerequisites
+
+Verify you're in a git repo. If not, tell the user and stop.
+
+Verify that CLI tools for the detected ticket system are available. If not, tell the user what to install and stop.
+
+### Derive project identity
+
+Determine the project root path, project name (from the directory name), and a short hash of the root path to prevent collisions between repos with the same name. Use these to construct a unique `PROJECT_ID` in the form `<project-name>-<hash>` and a cache directory path in the system temp directory: `<temp>/product-planner-<PROJECT_ID>`.
+
+### Destroy stale cache
+
+Remove the cache directory if it exists, then recreate it empty.
+
+### Parse time window (refine mode only)
+
+If the skill argument is `refine <duration>` (e.g., `refine 5h`), extract the duration and compute a cutoff ISO timestamp. The duration matches `^[0-9]+[mhd]$` (minutes, hours, or days). If no duration or invalid format, no cutoff is applied and refine targets all open tickets.
+
+### Cache tickets (two-tier)
+
+Using the detected ticket system's CLI tools, MCP tools, or APIs, fetch tickets in two tiers:
+
+**Open tickets (full detail):** Fetch all open tickets with full detail (ID, title, body/description, labels/tags, state, creation date, update date, comments, author, URL). When a time window is active (refine mode with duration), filter to only tickets created within the window. Write to `<cache>/issues-open.json`.
+
+If time-windowed refine returns zero results, tell the user and stop. Do not dispatch sub-agents.
+
+**Closed tickets (titles only):** Fetch recently closed tickets labeled `product` or `architecture` (titles, IDs, and labels only). Merge into a single deduplicated list. Write to `<cache>/issues-closed.json`.
+
+Normalize all fetched data into a consistent JSON shape regardless of the source platform.
+
+### Build the project map
+
+Explore the codebase and write a **project map** to `<cache>/project-map.md`. This is pointers and structure, NOT file contents. Sub-agents will read actual files themselves; the map just tells them what exists and where so they skip discovery.
+
+1. Read CLAUDE.md, README.md, and the dependency manifest (package.json / pyproject.toml / Cargo.toml / go.mod)
+2. Run a directory structure listing (pruned to reasonable depth, excluding .git and dependency directories)
+3. Identify entry points, key UI components, route definitions, and patterns
+4. Write the map
+
+The map should include:
+- **Tech stack**: language, framework, database, testing tools (extracted from dependency manifest)
+- **Directory structure**: actual tree output, pruned to reasonable depth
+- **Key files**: path + one-line description of what it does (entry points, routes, components, layouts, config)
+- **Product context**: what the product promises the user (from README), who the user is, core workflows
+- **Conventions from CLAUDE.md**: note any project-specific conventions that affect auditing
+
+Keep the map factual and concise. No code snippets. No opinions. Just a guide to the terrain.
+
+### Assign tickets to clusters
+
+Each open ticket must be assigned to exactly one cluster to prevent multiple agents from editing the same ticket concurrently. This applies to both create and refine modes.
+
+1. Read `<cache>/issues-open.json`
+2. For each ticket, determine the single best-fit cluster based on its title, body, and labels
+3. Write per-cluster edit files (filtered subsets of the open tickets JSON):
+   - `<cache>/issues-edit-core-experience.json`
+   - `<cache>/issues-edit-error-edge.json`
+   - `<cache>/issues-edit-polish.json`
+   - `<cache>/issues-edit-reach-access.json`
+   - Empty clusters get an empty array
+
+4. Print the assignment table so the user can see it:
+
+```
+Ticket Assignment:
+  <id> "Ticket title..." -> Core Experience
+  <id> "Ticket title..." -> Error & Edge States
+  ...
+```
+
+**Assignment rules:**
+- Every ticket gets assigned to exactly one cluster. No ticket is left unassigned.
+- Match by primary concern, not tangential relevance.
+- When a ticket spans multiple clusters, assign to the cluster that owns the root concern.
+- Tickets with no clear fit: assign to the cluster with the most overlapping focus areas.
+
+**Cluster slugs:** `core-experience`, `error-edge`, `polish`, `reach-access`
+
+## Step 2: Coverage Status
+
+Check the planner state file at `<temp>/planner-state/<PROJECT_ID>.json`. Create the directory and file if they don't exist.
+
+**You MUST print coverage status so the user knows when this was last run:**
+
+```
+Coverage Status (product-planner):
+Last run: 2026-03-15 10:30
+Mode: create | refine | refine (last 5h, tickets since 2026-03-17T14:00:00Z)
+
+Clusters: Core Experience, Error & Edge States, Polish & Consistency, Reach & Access
+```
+
+Read the `product-planner` value from the state file for the "Last run" timestamp. If null or missing, show "never". Show the active mode and, if time-windowed refine, the window and cutoff.
+
+## Step 3: Deploy Cluster Agents
+
+Spawn **4 sub-agents in parallel using the Agent tool**, one per cluster. **All 4 MUST be in a single message** so they run concurrently. Use `description: "Audit <ClusterName> cluster"` for each.
+
+For each cluster, construct a prompt by taking the Sub-Agent Prompt Template below and replacing:
+- `{MODE}` with `create` or `refine`
+- `{CACHE_DIR}` with the actual cache directory path
+- `{CLUSTER_NAME}`, `{CLUSTER_DESCRIPTION}`, `{FOCUS_TABLE}` with the cluster's content from Cluster Definitions
+- `{CLUSTER_SLUG}` with the cluster's slug from the assignment step
+- `{MODE_SECTION}` with the Full Mode or Refine Mode block from Mode-Specific Sections
+- `{TICKET_SYSTEM}` with the detected ticket system name
+
+---
+
+### Sub-Agent Prompt Template
+
+```
+You are a product manager who just watched a real user try this app for the first time. You are one of 4 parallel agents, each focused on a different concern cluster.
+
+## Mode: {MODE}
+
+## Ticket System: {TICKET_SYSTEM}
+
+Use whatever CLI tools, MCP tools, or APIs are available to interact with the ticket system. Adapt commands to the platform (e.g., `gh issue create` for GitHub, `jira issue create` for Jira, `glab issue create` for GitLab, etc.).
+
+## Cached Tickets
+
+Do NOT fetch ticket lists yourself. Tickets are cached on disk.
+
+- `{CACHE_DIR}/issues-open.json` — all open tickets with full detail. **Read-only context** for awareness and cross-references.
+- `{CACHE_DIR}/issues-edit-{CLUSTER_SLUG}.json` — tickets assigned to YOUR cluster. You may ONLY modify tickets in this file.
+- `{CACHE_DIR}/issues-closed.json` — closed tickets with titles and labels only. Check this before filing new tickets to avoid duplicating something already resolved.
+
+**Edit constraint:** You may ONLY execute write commands (edit, close, create) against tickets in your edit file. For tickets outside your edit file, you have read-only access via `issues-open.json`. If you discover something relevant to a ticket outside your cluster, write it to your cross-cluster notes file at `{CACHE_DIR}/cross-cluster-{CLUSTER_SLUG}.json`. Do NOT add comments to any ticket.
+
+Use the labels/tags to distinguish ticket types. Tickets labeled `product` are yours; tickets labeled `architecture` are cross-reference. Tickets with neither label may need triage.
+
+Read every open ticket title in `issues-open.json`. Note which topics are covered.
+If an architecture ticket covers a related technical concern, don't duplicate. Reference it and focus on the user-facing impact.
+
+## Cross-Cluster Notes
+
+If you discover a finding relevant to a ticket outside your edit file, write it to your cross-cluster notes file at `{CACHE_DIR}/cross-cluster-{CLUSTER_SLUG}.json`. Write a JSON array of objects:
+
+\`\`\`json
+[
+  {
+    "target_issue": 239,
+    "finding": "What you discovered, with file paths and evidence",
+    "related_issues": [234, 237]
+  }
+]
+\`\`\`
+
+If you have no cross-cluster findings, write an empty array: `[]`
+
+A post-processor will read your notes after all cluster agents finish and weave the findings into the target tickets' descriptions. Do not attempt to do this yourself.
+
+## Orient
+
+Start by reading the project map at `{CACHE_DIR}/project-map.md`. It tells you the tech stack, directory structure, key files, product context, and who the user is. This replaces independent exploration. Do NOT run directory listings or search for entry points. The map has this.
+
+Then read the actual files relevant to your cluster directly from the project. The map tells you what exists; you read the code that matters for your focus areas.
+
+Judge against what the product promises, not abstract ideals.
+
+## Your Cluster: {CLUSTER_NAME}
+
+{CLUSTER_DESCRIPTION}
+
+{FOCUS_TABLE}
+
+Deep-read code for ALL focus areas in this cluster.
+
+Before assessing any file, check for recent activity:
+git log --since="3 days ago" --oneline -- <file>
+Note recent commits in tickets or skip if being addressed.
+
+{MODE_SECTION}
+
+## Stay In Your Lane
+
+File about: UX, flows, missing states, confusing UI, visual inconsistency, navigation/state issues, destructive action safety, data presentation, accessibility, user-facing gaps
+NOT about: Code quality, security, performance internals, test coverage, dependency versions
+```
+
+---
+
+### Cluster Definitions
+
+**Core Experience** - Can the user figure out what to do, do it, and know it worked? Onboarding, task completion, feedback, findability.
+
+| Focus Area | What to Look For |
+|------------|-----------------|
+| **First-run experience** | Onboarding, empty states, "what do I do now?" moments |
+| **Workflow completeness** | Can the user finish what they started? Dead ends? |
+| **Feedback loops** | Does the user know what worked? What's pending? What broke? |
+| **Information architecture** | Can users find things? Is navigation logical? |
+
+**Error & Edge States** - What happens when things go wrong or get weird? Failures, dangerous actions, back/forward/refresh behavior.
+
+| Focus Area | What to Look For |
+|------------|-----------------|
+| **Error & loading states** | What happens when things fail? Spinners? Blank screens? |
+| **Destructive action safety** | Missing confirmations for irreversible actions, no undo capability, easy to accidentally trigger deletes/overwrites, no "are you sure?" for data loss |
+| **State & navigation** | Browser back/forward behavior, refresh losing state, URLs not reflecting current view (deep linking), navigating away mid-action and returning, bookmark-ability |
+
+**Polish & Consistency** - Does it feel like one product? Consistent language, visuals, and data formatting.
+
+| Focus Area | What to Look For |
+|------------|-----------------|
+| **Terminology & copy** | Jargon, inconsistent labels, ambiguous buttons |
+| **Visual & design consistency** | Inconsistent spacing/colors/typography across views, similar actions styled differently, design tokens not applied uniformly, components that do the same thing but look different |
+| **Data presentation** | Inconsistent date/number formatting, text overflow/truncation, how empty or null values display, surprising sort orders, long content breaking layouts |
+
+**Reach & Access** - Can everyone use it? Keyboard/screen reader support, small screens, multi-user scenarios, expected features.
+
+| Focus Area | What to Look For |
+|------------|-----------------|
+| **Accessibility** | Keyboard nav, screen readers, contrast, focus management |
+| **Mobile / responsive** | Does it work on small screens? |
+| **Permissions & roles** | Multi-user scenarios, what happens with no access? |
+| **Competitive table stakes** | Features users expect from similar tools that are missing |
+
+---
+
+### Mode-Specific Sections
+
+**Create mode** (no argument or `create`), insert as `{MODE_SECTION}`:
+
+```
+## Create New Tickets
+
+Your job: find NEW product gaps in the codebase within your cluster's focus areas and file well-formed tickets.
+
+Hard cap: maximum 3 new tickets.
+
+### Dedup Check
+
+Before creating any ticket, scan existing tickets for overlap:
+1. Read ticket titles and descriptions in issues-open.json. Is this problem already covered?
+2. Check issues-closed.json titles. Was this already filed and resolved?
+3. If already covered and your finding adds context: if the ticket is in your edit file, edit the description directly. If it is outside your edit file, write it to your cross-cluster notes file. Do NOT add comments. Do NOT rewrite existing ticket descriptions, that's refine's job.
+4. If not covered: create a new focused ticket.
+
+If you notice an existing ticket has obviously wrong info (e.g., references a component that no longer exists, wrong label), fix it. But do NOT deeply scrutinize, rewrite descriptions, or re-evaluate severity, that's refine's job.
+
+### Pre-Filing Gate
+
+Before filing, ask: "What does the fix look like, and is the current behavior actually wrong?" If the existing UX already handles the case (a button that resets IS a retry path, a transport fallback that delivers the same data ISN'T broken, a pessimistic delete that keeps the item visible on failure IS correct), there's no issue. If the fix wouldn't survive a "would a senior PM prioritize this?" test, don't file it.
+
+### Filing
+
+Create a new ticket with the `product` label and a severity label (`severity:high`, `severity:medium`, or `severity:low`). Use the following structure for the body:
+
+## Problem
+What the user experiences. Be specific, reference the actual screen/flow/component.
+
+## Impact
+Why this matters to the user. What do they feel or fail to do?
+
+## Suggested Direction
+How this could be addressed (not implementation details, product direction).
+
+Severity guide:
+- severity:high: User cannot complete a core workflow, or dealbreaker in competitive evaluation
+- severity:medium: User can work around it, but causes friction or confusion
+- severity:low: Polish, nice-to-have, minor inconsistency
+
+Rules:
+- One problem per ticket
+- Label all tickets product + a severity label
+- Never file code bugs, security issues, or architectural concerns
+- Reference specific files, routes, or components you actually read
+- If unsure something is a real problem, read the code to verify before filing
+```
+
+**Refine mode** (`refine` or `refine <duration>`), insert as `{MODE_SECTION}`:
+
+```
+## Refine Existing Tickets
+
+Your job: improve existing tickets related to your cluster. Do NOT create new tickets.
+
+Prioritize:
+1. Open tickets related to your cluster's focus areas
+2. Oldest open tickets without recent comments
+3. Tickets related to code you just read
+
+For each ticket you deep-read, ask:
+- Still true? Read the code NOW. Close with evidence if fixed.
+- Accurate? If it mischaracterizes the problem, rewrite the description with the correct analysis.
+- Complete? Add file paths, affected user flows, severity context to the description.
+- Scoped right? Split conflated tickets. Note broader patterns.
+- Priority right? Re-evaluate and update the severity label.
+
+### Editing tickets: description is the source of truth
+
+**When the ticket's core content needs changing** (problem statement, impact, severity, suggested direction), **edit the description directly**. The description must always be the canonical, accurate statement. Do NOT leave corrections as comments while the description stays wrong.
+
+**When synthesizing:** If the ticket has comments from the same user as you (prior skill runs), fold their corrections and additions into the description, then delete those comments. The description becomes one clean, authoritative ticket. Never touch comments from other users.
+
+Do not add comments to any ticket. All findings, cross-references, and dependency notes belong in the ticket description. If the target ticket is in your edit file, edit the description directly. If it is outside your edit file, write to your cross-cluster notes file.
+
+### Available operations
+
+Ticket bodies and comments are already in issues-open.json, no need to fetch them again.
+
+- Edit a ticket's description
+- Delete a redundant comment from a prior skill run (after synthesizing into description)
+- Close a resolved ticket (add a Resolution section to the description first, then close)
+
+Use whatever CLI tools or APIs are available for the detected ticket system.
+
+Do not rubber-stamp. If something feels off, dig in.
+```
+
+---
+
+## Step 3.5: Post-Process Cross-Cluster Notes
+
+After all 4 sub-agents complete, check for cross-cluster findings:
+
+1. Read all cross-cluster note files from the cache directory:
+   - `cross-cluster-core-experience.json`
+   - `cross-cluster-error-edge.json`
+   - `cross-cluster-polish.json`
+   - `cross-cluster-reach-access.json`
+
+2. Collect all notes into a single list. If every file is an empty array or missing, skip to Step 4.
+
+3. If there are notes, spawn a single **foreground** post-processor agent with the collected notes **inlined in the prompt** (not as file paths, since the cache will be cleaned after).
+
+### Post-Processor Agent Prompt
+
+```
+You are a post-processor for the product-planner. Parallel cluster agents have completed their work and left cross-cluster findings that need to be woven into ticket descriptions. Your job is to incorporate each finding into the target ticket's description.
+
+## Ticket System: {TICKET_SYSTEM}
+
+Use whatever CLI tools, MCP tools, or APIs are available to interact with the ticket system.
+
+## Rules
+
+- Process one ticket at a time, sequentially
+- For each target ticket: read the current description, then edit it to incorporate the finding
+- Weave findings into the appropriate existing section of the description. Do not append a generic "Cross-Cluster Findings" section. Use editorial judgment to place the finding where it belongs contextually.
+- If a finding is a simple cross-reference ("Related to <id>"), add it inline near the relevant content in the description
+- If a finding adds substantive analysis, integrate it into the relevant section (Problem, Impact, Suggested Direction, etc.)
+- Do NOT create new tickets, close tickets, or add comments
+- Do NOT change content that was already in the description, only add the new findings
+
+## Cross-Cluster Findings
+
+{COLLECTED_NOTES_JSON}
+```
+
+---
+
+## Step 4: Cleanup & Update State
+
+After all sub-agents and post-processing complete:
+
+**Delete the cache directory and verify it's gone.** If cleanup fails, do NOT proceed. Investigate and retry. Stale cache left behind will corrupt the next run.
+
+**Update the state file** at `<temp>/planner-state/<PROJECT_ID>.json`. Read the existing JSON, set `product-planner` to the current ISO timestamp (e.g., `2026-03-15T10:30:00`). Write back. Preserve any existing `architect-planner` data.

--- a/skills/ship
+++ b/skills/ship
@@ -1,1 +1,0 @@
-/Users/adam/.claude/skills/ship

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: ship
+description: Commit, push, create/merge PR, sync local main, delete branch. The standard "I'm done with this branch" workflow.
+---
+
+# Ship
+
+Complete the current branch by committing, pushing, merging, and cleaning up.
+
+## Steps
+
+1. **Review uncommitted changes**: Run `git status` and `git diff` to see what's uncommitted. If any files or changes look suspect, prompt the user and wait for confirmation before committing.
+2. **Commit**: Stage and commit the confirmed changes with a descriptive message based on the diff.
+3. **Push**: Push the current branch to origin with `-u` flag if not already pushed.
+4. **Create PR** (if none exists): Create a PR using `gh pr create`. Use commit messages to generate the title and body. For forked repos, use `--repo` targeting the user's fork (origin), never upstream.
+5. **Resolve merge strategy**: Read cached repository policy from `$(git rev-parse --git-dir)/agents/repo-policy.json` if present and fresh. If missing, stale, invalid, or for a different repository, refresh it with `gh repo view --json nameWithOwner,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,deleteBranchOnMerge` and write the result back to the cache.
+6. **Merge PR**: Choose the first allowed strategy in this order: `--merge` when `mergeCommitAllowed` is true, else `--squash` when `squashMergeAllowed` is true, else `--rebase` when `rebaseMergeAllowed` is true. Merge with `gh pr merge <strategy>`. For forked repos, use `--repo` targeting the fork. If no strategy is allowed, stop and report the repository merge policy.
+7. **Sync main**: `git checkout main && git pull origin main`
+8. **Clean up**: Delete the merged branch locally (`git branch -D`). Only delete the remote branch (`git push origin --delete`) if it still exists — some repos auto-delete branches on merge.
+9. **Report**: Confirm done with the merged PR URL.
+
+## Repository Policy Cache
+
+- Cache repository-local operational policy in the Git directory at `$(git rev-parse --git-dir)/agents/repo-policy.json`. Do not assume `.git` is a directory; always resolve it with `git rev-parse --git-dir` so worktrees are handled correctly.
+- This cache is local, uncommitted, shared by coding agents, and disposable.
+- For GitHub merge policy, cache this shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "repository": "owner/name",
+  "github": {
+    "mergePolicy": {
+      "mergeCommitAllowed": false,
+      "squashMergeAllowed": true,
+      "rebaseMergeAllowed": true,
+      "deleteBranchOnMerge": true,
+      "fetchedAt": "2026-04-15T16:55:00Z"
+    }
+  }
+}
+```
+
+- Treat the cache as fresh for 30 days. If a merge command fails with a repository policy error, refresh the cache once and retry only with an allowed strategy. Do not retry other merge failures.
+
+## Rules
+
+- For forked repos (where origin and upstream differ), NEVER create or merge PRs on the upstream repo. Always target the user's fork (origin).
+- If the branch has no commits ahead of main and no uncommitted changes, warn and stop.
+- If there's an open PR already, push any new commits to update it, then merge it.
+- If the merge fails due to stale repository policy cache, refresh the cache once and retry only with an allowed strategy.
+- If the merge fails for any other reason, report the error — don't retry or force.
+- Do not bypass failing required checks, conflicts, review requirements, or permissions errors.
+- If on main, warn and stop — ship only works on feature branches.


### PR DESCRIPTION
## Summary
- Invert the symlink direction: agentic-toolkit now holds the source-of-truth content for skills instead of symlinking out to `~/.claude/skills/*`.
- `~/.claude/skills/<skill>` will be repointed (post-merge) as per-skill symlinks back into this repo, so Claude Code loads the same files directly.
- Eliminates the git-blindness that hid content changes behind symlink pointers and prevents the two locations from drifting.

## Changes bundled in
- `ship`: merge-strategy checks (today's work)
- `architect-planner`: architectural synthesis step for sub-agents
- `next-ticket` / `pr` / `convert-worktree`: validation and caching refinements

## Test plan
- [ ] Verify SKILL.md content matches current `~/.claude/skills/<skill>/SKILL.md` for all 7 skills
- [ ] Post-merge: replace `~/.claude/skills/<skill>` with symlinks into `~/workspace/agentic-toolkit/skills/<skill>`
- [ ] Confirm Claude Code still loads each skill in a fresh session
- [ ] Confirm user-local skills (e.g. playwright) remain untouched in `~/.claude/skills`