### PR TITLE
Set pr, ship, and convert-worktree skills to sonnet

### DIFF
--- a/skills/convert-worktree/SKILL.md
+++ b/skills/convert-worktree/SKILL.md
@@ -2,6 +2,7 @@
 name: convert-worktree
 description: Convert a git worktree into a local branch. Rebase onto latest main, clean up project resources, remove worktree, checkout branch in main workspace. Use when finishing work in a worktree.
 disable-model-invocation: true
+model: sonnet
 ---
 
 # Convert Worktree

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr
 description: Format, lint, test, commit, push, and create a pull request. The single "I'm done" command.
+model: sonnet
 ---
 
 # PR: Format, Lint, Test, Commit, Push, Create Pull Request

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ship
 description: Commit, push, create/merge PR, sync local main, delete branch. The standard "I'm done with this branch" workflow.
+model: sonnet
 ---
 
 # Ship


### PR DESCRIPTION
## Summary

Adds `model: sonnet` frontmatter to three skills whose work is entirely mechanical:

- `pr` — format, lint, test, commit, push, create PR
- `ship` — commit, push, merge, sync main, cleanup
- `convert-worktree` — git worktree detection, commit, rebase, remove, checkout

These skills don't analyze code or spawn analytical sub-agents, so running them on Sonnet saves tokens with no quality trade-off.

## Why not the planner skills

Researched and considered. The planner orchestrators do mostly mechanical work, but they spawn 4 parallel cluster sub-agents that must stay on Opus for deep code analysis. The only way to keep the orchestrator on Sonnet while keeping the sub-agents on Opus is to hardcode \`model: "opus"\` on the Agent calls, which breaks for users on plans without Opus access (e.g., Team basic seat). The platform does not offer a per-invocation "use Opus if available, else Sonnet" selector. Given the orchestrator is only ~5-15% of planner spend and the optimization creates real access-breakage risk, the planners are left alone.

## Why \`sonnet\` alias vs. pinned version

The \`sonnet\` alias auto-resolves to the latest Sonnet model, so these skills stay on the current recommended Sonnet as new versions ship.

## Test plan

- [ ] Invoke \`/pr\` and confirm it runs on Sonnet
- [ ] Invoke \`/ship\` and confirm it runs on Sonnet
- [ ] Invoke \`/convert-worktree\` from inside a worktree and confirm it runs on Sonnet