### PR TITLE
feat(skill): add update-deps skill

### DIFF
--- a/docs/superpowers/plans/2026-04-19-update-deps.md
+++ b/docs/superpowers/plans/2026-04-19-update-deps.md
@@ -1,0 +1,646 @@
+# update-deps Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a `skills/update-deps/SKILL.md` that instructs an LLM agent to update project dependencies: discover CVE-required updates from bot PRs, apply safe minor/patch updates, research breaking changes for major bumps via parallel sub-agents, and sequentially apply major bumps with tests.
+
+**Architecture:** Single SKILL.md file following the hybrid orchestrator pattern. Linear steps for discovery and safe updates (Steps 1-4), parallel sub-agent dispatch for major bump research (Steps 5-6), sequential application with TDD for major bumps (Step 7), finalization (Steps 8-9). Follows the conventions established by `triage-bugs/SKILL.md` (sub-agent templates) and `pr/SKILL.md` (linear flow).
+
+**Tech Stack:** Markdown skill file (no runtime code). Follows the agentic-toolkit plugin format with YAML frontmatter.
+
+**Reference files:**
+- Design spec: `docs/superpowers/specs/2026-04-19-update-deps-design.md`
+- Pattern: `skills/triage-bugs/SKILL.md` (sub-agent template pattern)
+- Pattern: `skills/pr/SKILL.md` (linear skill pattern)
+- Pattern: `skills/next-ticket/SKILL.md` (argument parsing, tool-agnostic detection)
+- Conventions: `AGENTS.md` (commit style, no em-dashes, no Co-Authored-By)
+
+---
+
+### Task 1: Create SKILL.md with Frontmatter, Overview, Arguments, Prerequisites, and Branch Naming
+
+**Files:**
+- Create: `skills/update-deps/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory and file with frontmatter through branch naming**
+
+Create `skills/update-deps/SKILL.md` with the following content:
+
+```markdown
+---
+name: update-deps
+description: Updates project dependencies. Checks open bot PRs for CVE patches, applies safe minor/patch updates, and researches/fixes breaking changes for major bumps. Optional scope (frontend|backend|infra|all) and major flag.
+argument-hint: "[<scope>[|<scope>...]] [major]"
+---
+
+# Update Dependencies
+
+Update project dependencies safely. Checks bot PRs for CVE-required patches, applies safe minor/patch updates in batch, and for major bumps: researches breaking changes online, scans the codebase for affected code, writes tests, fixes code, and validates.
+
+You are a **hybrid orchestrator**. Steps 1-4 are linear (discovery and safe updates). Steps 5-6 dispatch parallel research sub-agents. Step 7 applies major bump changes sequentially. Steps 8-9 finalize.
+
+## Arguments
+
+Check the argument passed to this skill:
+
+- **No argument**: All scopes, CVE-required major bumps + safe minor/patch only
+- **Scope tokens**: `frontend`, `backend`, `infra`, or `all` (default). Pipe-separate for multiple: `frontend|backend`
+- **`major` keyword**: Upgrade ALL deps to latest, including non-CVE major bumps, using thorough research approach
+
+Parsing: split on whitespace. Tokens containing `|` or matching a scope name are scope specifiers. The token `major` enables full-major mode. No argument = scope `all`, no major flag.
+
+Usage: `/update-deps`, `/update-deps frontend`, `/update-deps backend|infra major`
+
+## Prerequisites
+
+Verify you're in a git repo. If not, tell the user and stop.
+
+Verify you're not on `main` or `master`. If you are, create the branch first (see Branch Naming below).
+
+## Branch Naming
+
+Create branch `chore/update-deps`. If a scope is specified, append it: `chore/update-deps-frontend`. If the branch already exists:
+- Clean (no uncommitted work): reuse it
+- Dirty (uncommitted changes): warn the user and stop
+```
+
+- [ ] **Step 2: Verify file structure**
+
+Run: `ls -la skills/update-deps/SKILL.md`
+Expected: file exists
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/update-deps/SKILL.md
+git commit -m "feat(skill): scaffold update-deps with frontmatter and overview"
+```
+
+---
+
+### Task 2: Write Steps 1-2 (Manifest Detection and CVE PR Scanning)
+
+**Files:**
+- Modify: `skills/update-deps/SKILL.md`
+
+- [ ] **Step 1: Append Step 1 (Detect Project Structure) to SKILL.md**
+
+Add after the Branch Naming section:
+
+```markdown
+
+## Step 1: Detect Project Structure and Scope Mapping
+
+Explore the repo to identify all dependency manifests. Use whatever package manager discovery mechanisms are available. Map each manifest to a scope using heuristics:
+
+- **frontend**: manifests whose dependencies or directory context indicate a UI framework or client-side code
+- **backend**: manifests whose dependencies or directory context indicate server-side code, APIs, workers
+- **infra**: Dockerfiles, docker-compose files, terraform configs, k8s manifests, CI/CD configs, IaC tool configs
+
+In monorepos, multiple manifests may exist. Classify each independently.
+
+Print the manifest map:
+
+\```
+Detected manifests:
+  packages/web/package.json        -> frontend
+  packages/api/package.json        -> backend
+  infra/terraform/versions.tf      -> infra
+  docker-compose.yml               -> infra
+\```
+
+If the user's scope arg filters to specific scopes, only matching manifests proceed. Discard the rest.
+```
+
+- [ ] **Step 2: Append Step 2 (Check Open PRs for CVE Patches) to SKILL.md**
+
+Add after Step 1:
+
+```markdown
+
+## Step 2: Check Open PRs for Automated CVE Patches
+
+Check open PRs from automated dependency bots (dependabot, renovate, snyk, etc.) using whatever CLI is available (e.g., `gh pr list`). Identify bot PRs by author name or label conventions.
+
+For each bot PR:
+
+- Extract the dependency name and target version from the PR title and body
+- Note the CVE or security advisory if referenced
+- Record whether the update is patch, minor, or major relative to the currently installed version
+
+These form the **CVE-required update list**. Every dep on this list MUST be updated, even if it requires a major bump.
+
+Do NOT merge these PRs. The skill updates the deps directly; the bots will auto-close their PRs when they detect the target version is met.
+
+If no bot PRs exist, the CVE-required list is empty. Proceed normally.
+```
+
+- [ ] **Step 3: Verify the content reads correctly**
+
+Run: `head -120 skills/update-deps/SKILL.md`
+Expected: frontmatter, overview, arguments, prerequisites, branch naming, Steps 1-2
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/update-deps/SKILL.md
+git commit -m "feat(skill): add manifest detection and CVE PR scanning steps"
+```
+
+---
+
+### Task 3: Write Steps 3-4 (Outdated Dependency Listing and Safe Updates)
+
+**Files:**
+- Modify: `skills/update-deps/SKILL.md`
+
+- [ ] **Step 1: Append Step 3 (List All Outdated Dependencies) to SKILL.md**
+
+Add after Step 2:
+
+```markdown
+
+## Step 3: List All Outdated Dependencies
+
+For each in-scope manifest, use the appropriate package manager commands to list outdated deps. Record current version, latest version, and bump type (patch, minor, major).
+
+Classify each outdated dep into exactly one bucket:
+
+| Bucket | Criteria | Action |
+|---|---|---|
+| **CVE-required** | Appears on the CVE-required list from Step 2 | MUST update, even if major |
+| **Safe** | Minor or patch bump, not on CVE list | Updated in batch |
+| **Major (optional)** | Major bump, not on CVE list | Only updated if `major` flag is set |
+
+Print the classification:
+
+\```
+Dependency audit:
+  CVE-required (N):
+    <pkg> <current> -> <target> (<bump>) -- <CVE-ID> via <bot> PR #<n>
+    ...
+
+  Safe updates (N):
+    <pkg> <current> -> <target> (<bump>)
+    ...
+
+  Major (skipped, use 'major' flag to include) (N):
+    <pkg> <current> -> <target> (major)
+    ...
+\```
+
+If nothing is outdated and no bot PRs exist, tell the user and stop. Don't create a branch.
+```
+
+- [ ] **Step 2: Append Step 4 (Apply Safe Updates) to SKILL.md**
+
+Add after Step 3:
+
+```markdown
+
+## Step 4: Apply Safe Updates
+
+Update all safe (minor/patch, non-CVE) deps in a single batch per manifest.
+
+1. Run the appropriate package manager update commands for all safe deps
+2. Run the project's test suite (check CLAUDE.md for the test command)
+3. **Tests pass**: commit all safe updates in a single commit:
+
+\```
+Update minor/patch dependencies
+
+- <pkg> <old> -> <new>
+- <pkg> <old> -> <new>
+- ...
+\```
+
+4. **Tests fail**: isolate which update caused the failure. Revert deps one at a time until tests pass. Exclude the offending dep from the batch and retry. Report any dep that can't be safely updated as needing manual attention.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/update-deps/SKILL.md
+git commit -m "feat(skill): add dependency classification and safe update steps"
+```
+
+---
+
+### Task 4: Write Steps 5-6 (Research Cache and Sub-Agent Dispatch)
+
+This is the most complex section. It includes the sub-agent prompt template following the pattern from `triage-bugs/SKILL.md`.
+
+**Files:**
+- Modify: `skills/update-deps/SKILL.md`
+
+- [ ] **Step 1: Append Step 5 (Build Research Cache) to SKILL.md**
+
+Add after Step 4:
+
+```markdown
+
+## Step 5: Build Research Cache
+
+If there are zero major bumps to process (no CVE-required majors and either no optional majors or `major` flag not set), **skip Steps 5-7 entirely**.
+
+### Derive project identity
+
+Determine the project root path, project name (from directory name), and a short hash of the root path. Construct `PROJECT_ID` as `<name>-<hash>` and create the cache directory at `<temp>/update-deps-<PROJECT_ID>`.
+
+### Destroy stale cache
+
+Remove the cache directory if it exists, then recreate it empty.
+
+### Write research requests
+
+Write `<cache>/research-requests.json` with an entry per major bump dep:
+
+\```json
+[
+  {
+    "package": "<name>",
+    "current_version": "<current>",
+    "target_version": "<target>",
+    "reason": "cve | major",
+    "cve_id": "<CVE-ID or null>",
+    "manifest": "<path/to/manifest>",
+    "scope": "<frontend|backend|infra>"
+  }
+]
+\```
+
+### Build project map
+
+Explore the codebase and write `<cache>/project-map.md`. This is pointers and structure for sub-agents to orient, not file contents.
+
+1. Read CLAUDE.md, README.md, and dependency manifests
+2. Run a directory structure listing (pruned, excluding .git and dependency directories)
+3. Identify entry points, key files, test patterns
+
+The map should include:
+- **Tech stack**: language, framework, database, testing tools
+- **Directory structure**: actual tree output, pruned to reasonable depth
+- **Key files**: path + one-line purpose
+- **Test patterns**: framework, naming conventions, where tests live, how to run them
+- **Conventions from CLAUDE.md**: project-specific conventions affecting the update
+```
+
+- [ ] **Step 2: Append Step 6 (Deploy Parallel Research Sub-Agents) with prompt template to SKILL.md**
+
+Add after Step 5:
+
+```markdown
+
+## Step 6: Deploy Parallel Research Sub-Agents
+
+Read `<cache>/research-requests.json`. Spawn **one sub-agent per major bump dep, ALL in a single message** so they run concurrently.
+
+For each dep, construct a prompt by taking the Research Sub-Agent Prompt Template below and replacing:
+- `{PACKAGE}` with the package name
+- `{CURRENT_VERSION}` with the current version
+- `{TARGET_VERSION}` with the target version
+- `{REASON}` with `cve` or `major`
+- `{CVE_ID}` with the CVE ID (or `N/A`)
+- `{MANIFEST}` with the manifest path
+- `{CACHE_DIR}` with the cache directory path
+
+Use `description: "Research <package> <current> -> <target>"` for each.
+
+---
+
+### Research Sub-Agent Prompt Template
+
+\```
+You are a dependency upgrade researcher. Your job is to thoroughly research the breaking changes between two versions of a package, scan the codebase for affected code, and produce a detailed change plan. You do NOT modify any code.
+
+## Your Assignment
+
+Package: {PACKAGE}
+Current version: {CURRENT_VERSION}
+Target version: {TARGET_VERSION}
+Reason: {REASON}
+CVE: {CVE_ID}
+Manifest: {MANIFEST}
+
+## Step 1: Research Breaking Changes Online
+
+Use WebSearch to find:
+
+1. **Official migration guide** for {PACKAGE} from {CURRENT_VERSION} to {TARGET_VERSION}
+2. **Changelog and release notes** for EVERY version between {CURRENT_VERSION} and {TARGET_VERSION}. Do not skip intermediate majors if the jump spans more than one.
+3. **Blog posts, GitHub discussions, and community resources** for known pitfalls, common migration mistakes, and workarounds
+
+Be thorough. Run multiple searches:
+- "{PACKAGE} migration guide {CURRENT_VERSION} to {TARGET_VERSION}"
+- "{PACKAGE} breaking changes {TARGET_VERSION}"
+- "{PACKAGE} upgrade guide"
+- "{PACKAGE} changelog"
+
+Read the actual pages, not just snippets. Extract every breaking change, deprecated API, removed feature, changed default, and new requirement.
+
+Compile a complete list of breaking changes with:
+- What changed
+- What replaces it (the migration path)
+- What version introduced the change
+
+## Step 2: Scan the Codebase for Affected Code
+
+Read the project map at `{CACHE_DIR}/project-map.md` to understand the codebase structure.
+
+For each breaking change identified in Step 1:
+
+1. Grep the codebase for usage of the affected API, function, pattern, or configuration
+2. Read each affected file to understand the context of usage
+3. Determine whether the breaking change actually impacts this codebase (some breaking changes affect APIs not used here)
+4. Note the specific file paths and line numbers where changes will be needed
+
+Also scan for:
+- Import statements for the package
+- Configuration files that reference the package
+- Deprecated API usage that may not be flagged as breaking but should be updated
+
+## Step 3: Write Change Plan
+
+Write your findings to `{CACHE_DIR}/change-plan-{PACKAGE}.json`:
+
+```json
+{
+  "package": "{PACKAGE}",
+  "current_version": "{CURRENT_VERSION}",
+  "target_version": "{TARGET_VERSION}",
+  "reason": "{REASON}",
+  "cve_id": "{CVE_ID}",
+  "breaking_changes": [
+    {
+      "description": "What changed",
+      "migration": "How to fix it",
+      "affected_files": ["path/to/file.ts:42", "path/to/other.ts:15"],
+      "test_strategy": "What to test to verify the migration"
+    }
+  ],
+  "deprecated_apis_used": [
+    {
+      "api": "The deprecated API",
+      "replacement": "What to use instead",
+      "affected_files": ["path/to/file.ts:28"]
+    }
+  ],
+  "new_requirements": "Any new runtime or environment requirements (e.g., Node.js >= 18)",
+  "estimated_risk": "low | medium | high",
+  "risk_rationale": "Why this risk level",
+  "sources": [
+    "URL of migration guide",
+    "URL of changelog"
+  ]
+}
+```
+
+If the package has no breaking changes affecting this codebase (all changes are internal or affect unused APIs), still write the plan file with empty `breaking_changes` and `deprecated_apis_used` arrays and `estimated_risk: "low"`.
+
+## Rules
+
+- Do NOT modify any code. Research and analysis only.
+- Do NOT skip intermediate versions. If upgrading from v2 to v5, research v3, v4, and v5 breaking changes.
+- Be specific about file paths and line numbers. The orchestrator will use these to apply changes.
+- Prefer official documentation over community sources when they conflict.
+- Note any breaking changes you're uncertain about. Flag uncertainty in the change plan rather than omitting.
+\```
+
+---
+```
+
+- [ ] **Step 3: Verify the sub-agent template renders correctly**
+
+Visually check that the nested code blocks inside the template use the correct escaping. The outer fence is the template delimiter; inner JSON code blocks must be indented or use different fence lengths to render properly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/update-deps/SKILL.md
+git commit -m "feat(skill): add research cache and parallel sub-agent dispatch"
+```
+
+---
+
+### Task 5: Write Step 7 (Sequential Major Bump Application)
+
+**Files:**
+- Modify: `skills/update-deps/SKILL.md`
+
+- [ ] **Step 1: Append Step 7 (Sequentially Apply Each Major Bump) to SKILL.md**
+
+Add after the sub-agent template section:
+
+```markdown
+
+## Step 7: Sequentially Apply Each Major Bump
+
+After all research sub-agents complete, read the change plans from the cache directory. Apply them one at a time, sequentially.
+
+### Determine application order
+
+If multiple major bumps could interact (e.g., a framework and a plugin for that framework, or a library and its type definitions), apply the foundational package first. Read the change plans to identify dependency relationships and order accordingly.
+
+### For each major bump dep:
+
+**7a. Write tests that exercise current behavior.**
+
+Before touching the dep, write tests (or extend existing tests) that cover the specific APIs, patterns, and call sites identified in the change plan's `affected_files` and `breaking_changes`. These tests pin the current behavior. Run them and confirm they pass. This is the "before" snapshot.
+
+If the change plan shows empty `breaking_changes` (no impact on this codebase), skip to 7f.
+
+**7b. Update the dependency.**
+
+Run the package manager command to update just this one dep to the target version. Update the lockfile.
+
+**7c. Run the "before" tests, expect failures.**
+
+Run the tests from 7a. Failures confirm the breaking changes are real and the tests cover the right surface area. If all tests pass, the breaking changes don't affect this codebase despite what the research found. Skip to 7f.
+
+**7d. Fix code according to the change plan.**
+
+Using the change plan as a guide, update every affected file:
+- Replace deprecated APIs with their replacements
+- Adjust call signatures, configuration, and patterns
+- Read the actual source documentation URLs from the plan's `sources` to verify accuracy, not just the plan summary
+
+**7e. Run tests until green.**
+
+Run the "before" tests from 7a plus the full project test suite. Iterate on fixes until all pass.
+
+If stuck after reasonable effort, report the issue to the user with full context (what failed, what you tried, what the breaking change docs say). Revert the dep bump (`git checkout -- <manifest> <lockfile>` and reinstall), commit the revert if any code changes were made, and move to the next dep. Do NOT silently give up.
+
+**7f. Commit.**
+
+One atomic commit per dep:
+
+\```
+Update <package> <old> -> <new> [(<CVE-ID>)]
+
+Breaking changes addressed:
+- <description> (<affected files>)
+- ...
+
+Migration guide: <url>
+\```
+
+If no breaking changes were addressed (clean upgrade), simplify:
+
+\```
+Update <package> <old> -> <new> [(<CVE-ID>)]
+
+No breaking changes affect this codebase.
+\```
+
+**7g. Repeat** for the next change plan.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add skills/update-deps/SKILL.md
+git commit -m "feat(skill): add sequential major bump application with TDD"
+```
+
+---
+
+### Task 6: Write Steps 8-9, Edge Cases, and Rules
+
+**Files:**
+- Modify: `skills/update-deps/SKILL.md`
+
+- [ ] **Step 1: Append Steps 8-9, Edge Cases, and Rules to SKILL.md**
+
+Add after Step 7:
+
+```markdown
+
+## Step 8: Final Validation
+
+After all deps are updated and committed:
+
+1. Run the full test suite one final time to catch interaction effects between independently applied updates.
+2. Run the project's linter and formatter (check CLAUDE.md for the commands). If they modify files, commit as "Auto-format and lint fixes".
+3. If the final test suite fails, identify which combination of updates caused the interaction and report to the user with full context.
+
+## Step 9: Cleanup and Summary
+
+Delete the cache directory (`<temp>/update-deps-<PROJECT_ID>`) and verify it's gone. If cleanup fails, investigate and retry.
+
+Print summary:
+
+\```
+Dependency update complete.
+
+Branch: chore/update-deps[-<scope>]
+Scope: <scope>
+Mode: standard | major
+
+Safe updates (1 commit):
+  <pkg> <old> -> <new>, <pkg> <old> -> <new>, ... (N deps)
+
+Major updates (N commits):
+  <pkg> <old> -> <new> [(<CVE-ID>)] -- N breaking changes addressed
+  ...
+
+Skipped (manual attention needed):
+  <pkg> <old> -> <new> -- <reason>
+  ...
+
+Bot PRs that should auto-close:
+  #<n> (<bot>: <pkg>)
+  ...
+
+All tests passing. Ready for review.
+\```
+
+Never push, create PRs, or merge. The user reviews first.
+
+## Edge Cases
+
+**No outdated deps**: If discovery finds nothing to update and no bot PRs, tell the user and stop. Don't create a branch.
+
+**No bot PRs but outdated deps exist**: Proceed normally. CVE-required list is empty.
+
+**Mixed CVE and major flag**: If a CVE-required dep also appears on the "all majors" list, process once with CVE noted in the commit message.
+
+**Lockfile-only updates**: Valid. Include in safe updates.
+
+**Workspaces and monorepos**: When multiple manifests share a lockfile (npm/yarn workspaces), update at the workspace root to avoid lockfile conflicts.
+
+## Rules
+
+- Never push or create PRs. The user reviews first.
+- Never merge bot PRs. Trust they'll auto-close.
+- Never skip a CVE-required update. If it can't be done, report exactly why.
+- Never update a dep outside the requested scope.
+- Always run tests after each major bump. No shortcuts.
+- If stuck on a major bump after reasonable effort, report with full context. Revert the dep bump and commit the revert if code can't be fixed.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add skills/update-deps/SKILL.md
+git commit -m "feat(skill): add finalization, edge cases, and rules"
+```
+
+---
+
+### Task 7: Full Review and Final Commit
+
+**Files:**
+- Review: `skills/update-deps/SKILL.md`
+- Reference: `docs/superpowers/specs/2026-04-19-update-deps-design.md`
+
+- [ ] **Step 1: Spec coverage check**
+
+Read the design spec at `docs/superpowers/specs/2026-04-19-update-deps-design.md` and the completed SKILL.md. Verify each spec requirement maps to a section in the skill:
+
+| Spec Section | SKILL.md Coverage |
+|---|---|
+| Arguments (scope, major) | Arguments section |
+| Frontmatter | YAML frontmatter |
+| Dependency classification (CVE/safe/major) | Step 3 |
+| Git strategy (single branch, atomic commits) | Branch Naming, Steps 4/7f |
+| Step 1: Detect structure | Step 1 |
+| Step 2: Check PRs | Step 2 |
+| Step 3: List outdated | Step 3 |
+| Step 4: Safe updates | Step 4 |
+| Step 5: Build cache | Step 5 |
+| Step 6: Sub-agents | Step 6 + template |
+| Step 7: Sequential apply | Step 7 (7a-7g) |
+| Step 8: Final validation | Step 8 |
+| Step 9: Cleanup/summary | Step 9 |
+| Edge cases | Edge Cases section |
+| Rules | Rules section |
+
+If any gap is found, add the missing content.
+
+- [ ] **Step 2: Style check against AGENTS.md**
+
+Verify:
+- No em-dashes (use commas instead)
+- No Co-Authored-By references
+- No TODOs
+- Commas for punctuation throughout
+
+- [ ] **Step 3: Pattern check against existing skills**
+
+Verify the skill follows conventions from existing skills:
+- Frontmatter matches format (`name`, `description`, `argument-hint`)
+- Sub-agent template uses `{PLACEHOLDER}` substitution like triage-bugs
+- Tool-agnostic language ("use whatever CLI tools are available")
+- Cache pattern matches triage skills (`<temp>/update-deps-<PROJECT_ID>`)
+- No hardcoded tool names except as examples
+
+- [ ] **Step 4: Fix any issues found in Steps 1-3**
+
+If any gaps, style violations, or pattern mismatches were found, fix them and amend the last commit.
+
+- [ ] **Step 5: Final commit if any fixes were made**
+
+```bash
+git add skills/update-deps/SKILL.md
+git commit -m "fix(skill): address review findings in update-deps"
+```

--- a/docs/superpowers/specs/2026-04-19-update-deps-design.md
+++ b/docs/superpowers/specs/2026-04-19-update-deps-design.md
@@ -1,0 +1,268 @@
+# update-deps Skill Design
+
+## Overview
+
+A hybrid orchestrator skill that updates project dependencies. It uses linear steps for discovery and safe updates, then parallel research sub-agents with cache-to-disk for major bumps, followed by sequential application of changes.
+
+The skill treats automated bot PRs (dependabot, renovate, snyk) as a discovery mechanism for CVE-required updates. It does not merge those PRs; instead it updates the deps directly, trusting the bots will auto-close their PRs when the target versions are met.
+
+## Arguments
+
+```
+/update-deps                          # all scopes, CVE majors + safe minor/patch
+/update-deps frontend                 # scope to frontend only
+/update-deps backend|infra            # multiple scopes
+/update-deps major                    # all scopes, upgrade ALL deps including majors
+/update-deps frontend major           # scoped + all majors
+```
+
+**Parsing**: split argument on whitespace. Any token containing `|` or matching a known scope name (`frontend`, `backend`, `infra`, `all`) is a scope specifier. The token `major` enables full-major mode. No argument defaults to scope `all` without major flag.
+
+**Scopes** are detected heuristically from project structure:
+
+- **frontend**: manifests whose deps/directory indicate a UI framework or client-side code
+- **backend**: manifests whose deps/directory indicate server-side code, APIs, workers
+- **infra**: Dockerfiles, docker-compose, terraform, k8s manifests, CI/CD configs, IaC tool configs
+
+In monorepos, multiple manifests may exist. Each gets classified independently.
+
+## Frontmatter
+
+```yaml
+---
+name: update-deps
+description: Updates project dependencies. Checks open bot PRs for CVE patches, applies safe minor/patch updates, and researches/fixes breaking changes for major bumps. Optional scope (frontend|backend|infra|all) and major flag.
+argument-hint: "[<scope>[|<scope>...]] [major]"
+---
+```
+
+## Architecture
+
+The skill is a **hybrid orchestrator**: linear steps for the straightforward parts (discovery, scope classification, safe updates, final summary), with triage-style parallel sub-agent dispatch and cache-to-disk for the major bump research phase.
+
+### Dependency Classification
+
+Every outdated dep is placed in exactly one bucket:
+
+| Bucket | Criteria | Behavior |
+|---|---|---|
+| **CVE-required** | Referenced by a bot PR with a security advisory | MUST update, even if major bump |
+| **Safe** | Minor or patch bump, not CVE-related | Updated automatically in a batch |
+| **Major (optional)** | Major bump, not CVE-required | Only updated when `major` flag is set |
+
+### Git Strategy
+
+- Single branch: `chore/update-deps` (or `chore/update-deps-<scope>` if scoped)
+- Atomic commits per dependency for major bumps (with breaking change notes in message)
+- Batched single commit for all safe minor/patch updates
+- Never push, never create PRs, never merge bot PRs
+
+## Steps
+
+### Step 1: Detect Project Structure and Scope Mapping
+
+The agent explores the repo to identify all dependency manifests and maps each to a scope using heuristics about directory names, dependency contents, and file types.
+
+Prints a manifest map:
+
+```
+Detected manifests:
+  packages/web/package.json        -> frontend
+  packages/api/package.json        -> backend
+  infra/terraform/versions.tf      -> infra
+  docker-compose.yml               -> infra
+```
+
+If the user's scope arg filters to specific scopes, only matching manifests proceed.
+
+### Step 2: Check Open PRs for Automated CVE Patches
+
+The agent checks open PRs from known bots (dependabot, renovate, snyk, etc.) using whatever CLI is available. For each bot PR:
+
+- Extract the dependency name and target version
+- Note the CVE or security advisory if referenced
+- Record whether the update is patch, minor, or major relative to current
+
+These become the **CVE-required update list**. Every dep on this list MUST be updated.
+
+### Step 3: List All Outdated Dependencies
+
+For each in-scope manifest, the agent uses the appropriate package manager commands to list outdated deps with current version, latest version, and bump type. Classifies each into CVE-required, safe, or major (optional).
+
+Prints the classification:
+
+```
+Dependency audit (backend scope):
+  CVE-required (2):
+    express 4.18.2 -> 5.1.0 (major) -- CVE-2024-XXXXX via dependabot PR #87
+    lodash 4.17.20 -> 4.17.21 (patch) -- CVE-2021-XXXXX via dependabot PR #92
+
+  Safe updates (8):
+    axios 1.6.0 -> 1.7.2 (minor)
+    dotenv 16.3.1 -> 16.4.1 (minor)
+    ...
+
+  Major (skipped, use 'major' flag to include) (3):
+    pg 8.11.0 -> 9.0.0 (major)
+    ...
+```
+
+### Step 4: Apply Safe Updates
+
+Updates all safe (minor/patch, non-CVE) deps in a single batch per manifest:
+
+1. Run appropriate update commands
+2. Run the project's test suite
+3. If tests pass: commit all safe updates in one commit listing the updated deps
+4. If tests fail: bisect to find which update caused the failure, revert that dep, retry. Deps that can't be safely updated get reported as needing manual attention.
+
+Commit message format:
+
+```
+Update minor/patch dependencies
+
+- axios 1.6.0 -> 1.7.2
+- dotenv 16.3.1 -> 16.4.1
+- typescript 5.3.2 -> 5.3.3
+```
+
+### Step 5: Build Research Cache
+
+If there are zero major bumps to process, skip Steps 5-7.
+
+Creates cache directory at `<temp>/update-deps-<PROJECT_ID>`. Writes:
+
+- `<cache>/research-requests.json`: array of objects with package name, current version, target version, reason (cve or major), CVE ID if applicable, manifest path, scope
+- `<cache>/project-map.md`: tech stack, directory structure, key files, test patterns (same concept as triage skills, trimmed to relevant scope)
+
+### Step 6: Deploy Parallel Research Sub-Agents
+
+Spawn one sub-agent per major bump dep, all in a single message for parallel execution. Each sub-agent:
+
+1. **Researches breaking changes online.** Uses WebSearch to find the official migration guide, changelog, and release notes covering every version between current and target. Reads blog posts, GitHub discussions, and community resources for known pitfalls. Thorough, not a single search query.
+
+2. **Scans the codebase for affected code.** Using the project map, greps and reads all files that import or use the dep. Identifies every call site, pattern, or API usage affected by a breaking change.
+
+3. **Drafts a change plan.** Writes to `<cache>/change-plan-<package-name>.json`:
+
+```json
+{
+  "package": "express",
+  "current_version": "4.18.2",
+  "target_version": "5.1.0",
+  "reason": "cve",
+  "breaking_changes": [
+    {
+      "description": "req.host now returns host without port",
+      "migration": "Use req.hostname instead, or parse port separately",
+      "affected_files": ["src/middleware/proxy.ts:42", "src/routes/health.ts:15"],
+      "test_strategy": "Test that host-based routing still works with and without port"
+    }
+  ],
+  "deprecated_apis_used": [
+    {
+      "api": "res.sendfile()",
+      "replacement": "res.sendFile()",
+      "affected_files": ["src/routes/static.ts:28"]
+    }
+  ],
+  "new_requirements": "Node.js >= 18 required",
+  "estimated_risk": "medium",
+  "sources": [
+    "https://expressjs.com/en/guide/migrating-5.html"
+  ]
+}
+```
+
+4. **Does NOT modify any code.** Research only.
+
+### Step 7: Sequentially Apply Each Major Bump
+
+The orchestrator reads each change plan and applies them one at a time. Order: if two major bumps could interact (e.g., a framework and its plugin), apply the framework first.
+
+For each major bump:
+
+**7a. Write tests that exercise current behavior.** Before touching the dep, write tests (or extend existing tests) covering the specific APIs and patterns from the change plan's affected_files and breaking_changes. Run tests, confirm they pass.
+
+**7b. Update the dependency.** Run the package manager command to update just this one dep.
+
+**7c. Run the "before" tests, expect failures.** Failures confirm the breaking changes are real and tests cover the right surface. If all tests still pass, the breaking changes don't affect this codebase; skip to 7f.
+
+**7d. Fix code according to the change plan.** Apply documented migration paths: replace deprecated APIs, adjust call signatures, update patterns. Read the actual breaking change documentation sources from the plan for accuracy.
+
+**7e. Run tests until green.** Run the "before" tests plus the full project test suite. Iterate on fixes. If stuck after reasonable effort, report the issue to the user with full context rather than giving up silently. Revert the dep bump and commit the revert if code can't be fixed.
+
+**7f. Commit.** One atomic commit per dep:
+
+```
+Update express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX)
+
+Breaking changes addressed:
+- req.host -> req.hostname (proxy.ts, health.ts)
+- res.sendfile() -> res.sendFile() (static.ts)
+
+Migration guide: https://expressjs.com/en/guide/migrating-5.html
+```
+
+**7g. Repeat** for the next change plan.
+
+### Step 8: Final Validation
+
+1. Run the full test suite to catch interaction effects between independently applied updates.
+2. Run the project's linter and formatter (from CLAUDE.md). Commit auto-fixes separately if needed.
+3. If the final test suite fails, identify which combination caused the interaction and report to the user.
+
+### Step 9: Cleanup and Summary
+
+Delete the cache directory and verify it's gone.
+
+Print summary:
+
+```
+Dependency update complete.
+
+Branch: chore/update-deps
+Scope: backend | all
+Mode: standard | major
+
+Safe updates (1 commit):
+  axios 1.6.0 -> 1.7.2, dotenv 16.3.1 -> 16.4.1, ... (8 deps)
+
+Major updates (2 commits):
+  express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX) -- 3 breaking changes addressed
+  pg 8.11.0 -> 9.0.0 -- 1 breaking change addressed
+
+Skipped (manual attention needed):
+  socket.io 4.6.0 -> 5.0.0 -- test failure in websocket.test.ts:44, see details above
+
+Bot PRs that should auto-close:
+  #87 (dependabot: express)
+  #92 (dependabot: lodash)
+
+All tests passing. Ready for review.
+```
+
+Never push, create PRs, or merge. User reviews first.
+
+## Edge Cases
+
+**Branch naming**: `chore/<issue>-update-deps` if there's a related issue, otherwise `chore/update-deps`. Append scope if specified: `chore/update-deps-frontend`. If the branch already exists with uncommitted work, warn the user and stop. If clean, reuse it.
+
+**No outdated deps**: If discovery finds nothing to update and no bot PRs, tell the user and stop. Don't create a branch.
+
+**No bot PRs but outdated deps exist**: Proceed normally. CVE-required list is empty.
+
+**Mixed CVE and major flag**: If a CVE-required dep also appears on the "all majors" list, process once, with CVE noted in the commit message.
+
+**Lockfile-only updates**: Valid. Include in safe updates.
+
+**Workspaces and monorepos**: When multiple manifests share a lockfile (npm/yarn workspaces), update at the workspace root to avoid lockfile conflicts.
+
+## Rules
+
+- Never push or create PRs. The user reviews first.
+- Never merge bot PRs. Trust they'll auto-close.
+- Never skip a CVE-required update. If it can't be done, report exactly why.
+- Never update a dep outside the requested scope.
+- Always run tests after each major bump. No shortcuts.
+- If stuck on a major bump after reasonable effort, report with full context. Revert the dep bump and commit the revert if code can't be fixed.

--- a/docs/superpowers/specs/2026-04-19-update-deps-design.md
+++ b/docs/superpowers/specs/2026-04-19-update-deps-design.md
@@ -114,7 +114,7 @@ Updates all safe (minor/patch, non-CVE) deps in a single batch per manifest:
 1. Run appropriate update commands
 2. Run the project's test suite
 3. If tests pass: commit all safe updates in one commit listing the updated deps
-4. If tests fail: bisect to find which update caused the failure, revert that dep, retry. Deps that can't be safely updated get reported as needing manual attention.
+4. If tests fail: isolate which update caused the failure (revert deps one at a time until tests pass), exclude that dep from the batch, and retry. Deps that can't be safely updated get reported as needing manual attention.
 
 Commit message format:
 
@@ -246,7 +246,7 @@ Never push, create PRs, or merge. User reviews first.
 
 ## Edge Cases
 
-**Branch naming**: `chore/<issue>-update-deps` if there's a related issue, otherwise `chore/update-deps`. Append scope if specified: `chore/update-deps-frontend`. If the branch already exists with uncommitted work, warn the user and stop. If clean, reuse it.
+**Branch naming**: `chore/update-deps`. Append scope if specified: `chore/update-deps-frontend`. If the branch already exists with uncommitted work, warn the user and stop. If clean, reuse it.
 
 **No outdated deps**: If discovery finds nothing to update and no bot PRs, tell the user and stop. Don't create a branch.
 

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: update-deps
+description: Updates project dependencies. Checks open bot PRs for CVE patches, applies safe minor/patch updates, and researches/fixes breaking changes for major bumps. Optional scope (frontend|backend|infra|all) and major flag.
+argument-hint: "[<scope>[|<scope>...]] [major]"
+---
+
+# Update Dependencies
+
+You are a **hybrid orchestrator**. Steps 1 through 4 are linear discovery and safe-update work. Steps 5 and 6 run parallel research sub-agents (one per major bump dependency). Step 7 applies major bumps sequentially. Steps 8 and 9 finalize and summarize.
+
+## Arguments
+
+Parse the argument string passed to this skill by splitting on whitespace.
+
+- Any token that contains `|` or exactly matches a known scope name (`frontend`, `backend`, `infra`, `all`) is a **scope specifier**.
+- The token `major` enables **full-major mode**, which upgrades all deps including non-CVE major bumps.
+- No argument defaults to scope `all` without the major flag.
+
+Examples:
+
+```
+/update-deps                          # all scopes, CVE majors + safe minor/patch
+/update-deps frontend                 # scope to frontend only
+/update-deps backend|infra            # multiple scopes
+/update-deps major                    # all scopes, upgrade ALL deps including majors
+/update-deps frontend major           # scoped + all majors
+```
+
+## Prerequisites
+
+Verify you are in a git repo. If not, tell the user and stop.
+
+Verify you are NOT on `main` or `master`. If you are, tell the user to create a feature branch and stop.
+
+## Branch Naming
+
+Branch name: `chore/update-deps` for all-scope runs, `chore/update-deps-<scope>` for a single named scope (e.g., `chore/update-deps-frontend`). For multi-scope runs, use `chore/update-deps`.
+
+Check whether the branch already exists:
+
+- If it exists and is **clean** (no uncommitted changes), check it out and reuse it.
+- If it exists and is **dirty** (uncommitted changes present), warn the user and stop. Do not overwrite in-progress work.
+- If it does not exist, create it from the current branch.
+
+## Step 1: Detect Project Structure and Scope Mapping
+
+Explore the repository to identify all dependency manifests. Classify each manifest into a scope using these heuristics:
+
+- **frontend**: `package.json` files whose `dependencies` include a UI framework (React, Vue, Angular, Svelte, Next, Nuxt, Remix, Vite, Webpack) or whose path includes `web`, `client`, `ui`, `frontend`, `app`.
+- **backend**: `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle` files whose path or deps indicate server-side code (`express`, `fastapi`, `actix`, `gin`, `spring`, workers, APIs).
+- **infra**: Dockerfiles, `docker-compose*.yml`, Terraform `.tf` files, Kubernetes manifests, CI/CD config files (`.github/workflows`, `.gitlab-ci.yml`, `buildkite.yml`), IaC tool configs.
+
+In monorepos, classify each manifest independently.
+
+If the user supplied a scope argument, filter the manifest list to matching scopes only. Manifests that do not match the requested scope are excluded from all subsequent steps.
+
+Print the manifest map:
+
+```
+Detected manifests:
+  packages/web/package.json        -> frontend
+  packages/api/package.json        -> backend
+  infra/terraform/versions.tf      -> infra
+  docker-compose.yml               -> infra
+```
+
+If no manifests match the requested scope, tell the user and stop.
+
+## Step 2: Check Open PRs for Automated CVE Patches
+
+Using whatever CLI is available (e.g., `gh pr list`), fetch open PRs authored by known dependency bots: `dependabot`, `renovate`, `snyk-bot`, `greenkeeper`.
+
+For each bot PR:
+
+1. Extract the dependency name and target version from the PR title or body.
+2. Note the CVE or security advisory ID if referenced.
+3. Determine whether the version bump is patch, minor, or major relative to the currently installed version.
+
+Build the **CVE-required update list**. Every dependency on this list MUST be updated regardless of bump magnitude.
+
+Do NOT merge, close, or comment on any bot PR. The bots will auto-close their PRs when the dependency version is satisfied.
+
+If no bot PRs are found, proceed normally. The CVE-required list is simply empty.
+
+## Step 3: List All Outdated Dependencies
+
+For each in-scope manifest, run the appropriate package manager command to list outdated dependencies with current version, available version, and bump type. Common commands:
+
+- npm: `npm outdated --json`
+- yarn: `yarn outdated --json`
+- pnpm: `pnpm outdated`
+- pip: `pip list --outdated`
+- cargo: `cargo outdated`
+- go: `go list -u -m all`
+- maven/gradle: use the versions plugin
+
+Classify every outdated dep into exactly one bucket:
+
+| Bucket | Criteria | Behavior |
+|---|---|---|
+| **CVE-required** | Referenced by a bot PR with a security advisory | MUST update, even if major bump |
+| **Safe** | Minor or patch bump, not CVE-related | Updated automatically in a batch |
+| **Major (optional)** | Major bump, not CVE-required | Only updated when `major` flag is set |
+
+If a dep appears in both the CVE-required list and would qualify for the major-optional bucket, place it in CVE-required and process it once.
+
+Print the classification:
+
+```
+Dependency audit (backend scope):
+  CVE-required (2):
+    express 4.18.2 -> 5.1.0 (major) -- CVE-2024-XXXXX via dependabot PR #87
+    lodash 4.17.20 -> 4.17.21 (patch) -- CVE-2021-XXXXX via dependabot PR #92
+
+  Safe updates (8):
+    axios 1.6.0 -> 1.7.2 (minor)
+    dotenv 16.3.1 -> 16.4.1 (minor)
+    ...
+
+  Major (skipped, use 'major' flag to include) (3):
+    pg 8.11.0 -> 9.0.0 (major)
+    ...
+```
+
+If no outdated deps are found and no bot PRs exist, tell the user everything is up to date and stop. Do not create a branch.
+
+Lockfile-only updates are valid. Include them in safe updates.
+
+## Step 4: Apply Safe Updates
+
+Apply all safe (minor/patch, non-CVE) dependencies in a single batch per manifest.
+
+1. Run the appropriate update command for each manifest (e.g., `npm update`, `pip install --upgrade`, `cargo update`).
+2. Run the project's full test suite.
+3. If tests pass, commit all safe updates in one commit per manifest, listing the updated deps:
+
+```
+Update minor/patch dependencies
+
+- axios 1.6.0 -> 1.7.2
+- dotenv 16.3.1 -> 16.4.1
+- typescript 5.3.2 -> 5.3.3
+```
+
+4. If tests fail, isolate the cause: revert deps one at a time until tests pass, identify the offending dep, exclude it from the batch, and retry the batch without it. Report any dep that cannot be safely updated as needing manual attention.
+
+**Workspace and monorepo note**: When multiple manifests share a lockfile (npm/yarn workspaces, pnpm workspaces), update at the workspace root to avoid lockfile conflicts.
+
+## Step 5: Build Research Cache
+
+**Skip Steps 5 through 7 entirely if there are zero major bumps to process** (zero CVE-required major bumps and either no major-optional deps or the `major` flag was not set).
+
+Derive a project identity: use the project root directory name plus a short hash of the root path to produce a unique `PROJECT_ID` in the form `<project-name>-<hash>`.
+
+Create a cache directory at `<temp>/update-deps-<PROJECT_ID>`. Remove and recreate it if it already exists.
+
+Write two files to the cache:
+
+**`<cache>/research-requests.json`**: a JSON array, one object per major bump dep to research:
+
+```json
+[
+  {
+    "package": "express",
+    "current_version": "4.18.2",
+    "target_version": "5.1.0",
+    "reason": "cve",
+    "cve_id": "CVE-2024-XXXXX",
+    "manifest": "packages/api/package.json",
+    "scope": "backend"
+  }
+]
+```
+
+`reason` is `"cve"` for CVE-required updates and `"major"` for major-optional updates.
+
+**`<cache>/project-map.md`**: a factual guide to the codebase trimmed to the in-scope manifests and their surrounding code. No file contents, only pointers. Include:
+
+- Tech stack (language, framework, test runner, extracted from manifests)
+- Directory structure (pruned tree, excluding `.git` and dependency directories)
+- Key files (path plus one-line description of purpose)
+- Test patterns (where tests live, how to run them)
+- Conventions from CLAUDE.md that affect dependency usage
+
+## Step 6: Deploy Parallel Research Sub-Agents
+
+Read `<cache>/research-requests.json`. Spawn one sub-agent per entry, **all in a single message** so they execute concurrently. Use `description: "Research <package> upgrade"` for each.
+
+For each entry, construct a prompt by substituting the placeholders in the Sub-Agent Prompt Template below.
+
+---
+
+### Sub-Agent Prompt Template
+
+```
+You are a dependency upgrade researcher. Your only job is to research breaking changes and scan the codebase for affected code. You do NOT modify any code. You write a structured change plan to disk.
+
+## Assignment
+
+- Package: {PACKAGE}
+- Current version: {CURRENT_VERSION}
+- Target version: {TARGET_VERSION}
+- Reason: {REASON}
+- CVE ID: {CVE_ID}
+- Manifest: {MANIFEST}
+- Cache directory: {CACHE_DIR}
+
+## Step 1: Research Breaking Changes Online
+
+Use WebSearch to find the official migration guide, changelog, and release notes for every version between {CURRENT_VERSION} and {TARGET_VERSION}. Do not stop at one query. Search for:
+
+- "{PACKAGE} {TARGET_VERSION} migration guide"
+- "{PACKAGE} {TARGET_VERSION} breaking changes"
+- "{PACKAGE} changelog {CURRENT_VERSION} to {TARGET_VERSION}"
+- "{PACKAGE} upgrade {CURRENT_VERSION} {TARGET_VERSION}"
+- GitHub release notes for the package repository
+
+Read the actual pages, not just search result snippets. Community resources, Stack Overflow threads, and GitHub Discussions often document real-world pitfalls that official docs miss.
+
+If a CVE ID is provided, also search for "{CVE_ID} {PACKAGE}" to understand the vulnerability and the fix.
+
+Compile a complete list of breaking changes, deprecated APIs, renamed symbols, changed call signatures, new minimum runtime requirements, and removed features.
+
+## Step 2: Scan the Codebase for Affected Code
+
+Read `{CACHE_DIR}/project-map.md` to orient yourself. Then grep and read every file that imports or uses {PACKAGE}. For each affected file:
+
+1. Note the file path and line numbers of every usage.
+2. Cross-reference each usage against the breaking changes you found in Step 1.
+3. Identify which usages require changes and which are unaffected.
+
+Do not run directory listings independently. Use the project map as your guide and read specific files directly.
+
+## Step 3: Write Change Plan
+
+Write a JSON change plan to `{CACHE_DIR}/change-plan-{PACKAGE}.json`:
+
+\`\`\`json
+{
+  "package": "{PACKAGE}",
+  "current_version": "{CURRENT_VERSION}",
+  "target_version": "{TARGET_VERSION}",
+  "reason": "{REASON}",
+  "breaking_changes": [
+    {
+      "description": "What changed",
+      "migration": "How to fix it",
+      "affected_files": ["src/file.ts:42", "src/other.ts:15"],
+      "test_strategy": "What behavior to test before and after"
+    }
+  ],
+  "deprecated_apis_used": [
+    {
+      "api": "old.api()",
+      "replacement": "new.api()",
+      "affected_files": ["src/routes/static.ts:28"]
+    }
+  ],
+  "new_requirements": "Any new runtime or platform requirements (e.g., Node.js >= 18)",
+  "estimated_risk": "low | medium | high",
+  "sources": [
+    "https://example.com/migration-guide"
+  ]
+}
+\`\`\`
+
+If there are no breaking changes that affect this codebase, `breaking_changes` and `deprecated_apis_used` may be empty arrays. Still write the file.
+
+## Rules
+
+- Do NOT modify any source files, manifests, lockfiles, or tests.
+- Do not skip intermediate versions. Breaking changes accumulate across minor versions.
+- Be specific about file paths and line numbers. Vague references are not useful.
+- If the package is not found in any import or usage in the codebase, note that in `new_requirements` and set `estimated_risk` to `"low"`.
+```
+
+---
+
+## Step 7: Sequentially Apply Each Major Bump
+
+After all research sub-agents complete, read every `change-plan-<package>.json` file from the cache directory.
+
+Determine application order: if two major bumps could interact (e.g., a framework and a plugin for that framework), apply the framework first. Otherwise apply in any order.
+
+For each change plan:
+
+### 7a. Write tests that pin current behavior
+
+Before touching the dependency, write tests (or extend existing tests) that exercise the specific APIs and call patterns listed in `breaking_changes[].affected_files` and `deprecated_apis_used[].affected_files`. Cover the `test_strategy` described in each breaking change entry. Run the tests and confirm they pass against the current version.
+
+### 7b. Update the dependency
+
+Run the package manager command to update just this one dependency to the target version.
+
+### 7c. Run the "before" tests, expect failures
+
+Run the tests you wrote in 7a. If they fail, the breaking changes are confirmed and your tests cover the right surface. Proceed to 7d.
+
+If all tests still pass, the breaking changes do not affect this codebase. Skip to 7f.
+
+### 7d. Fix code according to the change plan
+
+Apply the documented migration paths: replace deprecated APIs, adjust call signatures, update patterns. Read the source documentation URLs listed in `sources` for accuracy when the plan is ambiguous.
+
+### 7e. Iterate until green
+
+Run the "before" tests plus the full project test suite. Fix remaining failures. Repeat.
+
+If you are stuck after reasonable effort, report the issue to the user with full context (which file, which test, which breaking change, what you tried). Revert the dependency bump with a commit that notes the revert reason. Do not give up silently.
+
+### 7f. Commit
+
+One atomic commit per dependency:
+
+```
+Update express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX)
+
+Breaking changes addressed:
+- req.host -> req.hostname (proxy.ts, health.ts)
+- res.sendfile() -> res.sendFile() (static.ts)
+
+Migration guide: https://expressjs.com/en/guide/migrating-5.html
+```
+
+For non-CVE major bumps, omit the CVE reference from the subject line.
+
+### 7g. Repeat for the next change plan
+
+## Step 8: Final Validation
+
+1. Run the full test suite to catch interaction effects between independently applied updates.
+2. Run the project's linter and formatter (check CLAUDE.md for commands). If auto-fixes are applied, commit them separately with message `Auto-format after dependency updates`.
+3. If the final test suite fails, identify which combination of updates caused the interaction and report it to the user.
+
+## Step 9: Cleanup and Summary
+
+Delete the cache directory and verify it is gone. If cleanup fails, investigate and retry before proceeding.
+
+Print the final summary:
+
+```
+Dependency update complete.
+
+Branch: chore/update-deps
+Scope: backend | all
+Mode: standard | major
+
+Safe updates (1 commit):
+  axios 1.6.0 -> 1.7.2, dotenv 16.3.1 -> 16.4.1, ... (8 deps)
+
+Major updates (2 commits):
+  express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX) -- 3 breaking changes addressed
+  pg 8.11.0 -> 9.0.0 -- 1 breaking change addressed
+
+Skipped (manual attention needed):
+  socket.io 4.6.0 -> 5.0.0 -- test failure in websocket.test.ts:44, see details above
+
+Bot PRs that should auto-close:
+  #87 (dependabot: express)
+  #92 (dependabot: lodash)
+
+All tests passing. Ready for review.
+```
+
+Never push, create PRs, or merge. The user reviews first.
+
+## Edge Cases
+
+**No outdated deps**: If discovery finds nothing to update and no bot PRs exist, tell the user and stop. Do not create a branch.
+
+**No bot PRs but outdated deps exist**: Proceed normally. The CVE-required list is empty.
+
+**Mixed CVE and major flag**: If a CVE-required dep also appears on the all-majors list, process it once, with CVE noted in the commit message.
+
+**Lockfile-only updates**: Valid. Include them in safe updates.
+
+**Workspaces and monorepos**: When multiple manifests share a lockfile (npm/yarn workspaces, pnpm workspaces), update at the workspace root to avoid lockfile conflicts.
+
+**Branch already exists and is dirty**: Warn the user and stop. Do not overwrite in-progress work.
+
+## Rules
+
+- Never push or create PRs. The user reviews first.
+- Never merge bot PRs. Trust they will auto-close when the target version is satisfied.
+- Never skip a CVE-required update. If it cannot be done, report exactly why.
+- Never update a dep outside the requested scope.
+- Always run tests after each major bump. No shortcuts.
+- If stuck on a major bump after reasonable effort, report with full context and revert the dep bump.

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -30,17 +30,11 @@ Examples:
 
 Verify you are in a git repo. If not, tell the user and stop.
 
-Verify you are NOT on `main` or `master`. If you are, tell the user to create a feature branch and stop.
+Note the current branch. Branch creation happens after Step 3 once we know there is work to do.
 
 ## Branch Naming
 
 Branch name: `chore/update-deps` for all-scope runs, `chore/update-deps-<scope>` for a single named scope (e.g., `chore/update-deps-frontend`). For multi-scope runs, use `chore/update-deps`.
-
-Check whether the branch already exists:
-
-- If it exists and is **clean** (no uncommitted changes), check it out and reuse it.
-- If it exists and is **dirty** (uncommitted changes present), warn the user and stop. Do not overwrite in-progress work.
-- If it does not exist, create it from the current branch.
 
 ## Step 1: Detect Project Structure and Scope Mapping
 
@@ -124,6 +118,12 @@ Dependency audit (backend scope):
 
 If no outdated deps are found and no bot PRs exist, tell the user everything is up to date and stop. Do not create a branch.
 
+If there is work to do, create the branch now using the convention from Branch Naming:
+
+- If it exists and is **clean** (no uncommitted changes), check it out and reuse it.
+- If it exists and is **dirty** (uncommitted changes present), warn the user and stop. Do not overwrite in-progress work.
+- If it does not exist, create it from the current branch.
+
 Lockfile-only updates are valid. Include them in safe updates.
 
 ## Step 4: Apply Safe Updates
@@ -184,9 +184,17 @@ Write two files to the cache:
 
 ## Step 6: Deploy Parallel Research Sub-Agents
 
-Read `<cache>/research-requests.json`. Spawn one sub-agent per entry, **all in a single message** so they execute concurrently. Use `description: "Research <package> upgrade"` for each.
+Read `<cache>/research-requests.json`. Spawn one sub-agent per entry, **all in a single message** so they execute concurrently. Use `description: "Research <package> <current> -> <target>"` for each.
 
-For each entry, construct a prompt by substituting the placeholders in the Sub-Agent Prompt Template below.
+For each entry, construct a prompt by substituting the placeholders in the Sub-Agent Prompt Template below:
+
+- `{PACKAGE}` with the package name from the research request
+- `{CURRENT_VERSION}` with the current installed version
+- `{TARGET_VERSION}` with the target version
+- `{REASON}` with `cve` or `major`
+- `{CVE_ID}` with the CVE ID, or `N/A` if not CVE-related
+- `{MANIFEST}` with the manifest file path
+- `{CACHE_DIR}` with the cache directory path
 
 ---
 
@@ -215,6 +223,8 @@ Use WebSearch to find the official migration guide, changelog, and release notes
 - "{PACKAGE} upgrade {CURRENT_VERSION} {TARGET_VERSION}"
 - GitHub release notes for the package repository
 
+If WebSearch is not available in your environment, check for local changelogs: `CHANGELOG.md`, `HISTORY.md`, or release notes in the package's repository. Use the package registry CLI to inspect available versions and their metadata.
+
 Read the actual pages, not just search result snippets. Community resources, Stack Overflow threads, and GitHub Discussions often document real-world pitfalls that official docs miss.
 
 If a CVE ID is provided, also search for "{CVE_ID} {PACKAGE}" to understand the vulnerability and the fix.
@@ -241,6 +251,7 @@ Write a JSON change plan to `{CACHE_DIR}/change-plan-{PACKAGE}.json`:
   "current_version": "{CURRENT_VERSION}",
   "target_version": "{TARGET_VERSION}",
   "reason": "{REASON}",
+  "cve_id": "{CVE_ID}",
   "breaking_changes": [
     {
       "description": "What changed",
@@ -258,6 +269,7 @@ Write a JSON change plan to `{CACHE_DIR}/change-plan-{PACKAGE}.json`:
   ],
   "new_requirements": "Any new runtime or platform requirements (e.g., Node.js >= 18)",
   "estimated_risk": "low | medium | high",
+  "risk_rationale": "Why this risk level",
   "sources": [
     "https://example.com/migration-guide"
   ]
@@ -285,6 +297,8 @@ Determine application order: if two major bumps could interact (e.g., a framewor
 For each change plan:
 
 ### 7a. Write tests that pin current behavior
+
+If the change plan has an empty `breaking_changes` array and an empty `deprecated_apis_used` array (no impact on this codebase), skip directly to 7f.
 
 Before touching the dependency, write tests (or extend existing tests) that exercise the specific APIs and call patterns listed in `breaking_changes[].affected_files` and `deprecated_apis_used[].affected_files`. Cover the `test_strategy` described in each breaking change entry. Run the tests and confirm they pass against the current version.
 
@@ -329,7 +343,7 @@ For non-CVE major bumps, omit the CVE reference from the subject line.
 ## Step 8: Final Validation
 
 1. Run the full test suite to catch interaction effects between independently applied updates.
-2. Run the project's linter and formatter (check CLAUDE.md for commands). If auto-fixes are applied, commit them separately with message `Auto-format after dependency updates`.
+2. Run the project's linter and formatter (check CLAUDE.md for commands). If auto-fixes are applied, commit them separately with message `Auto-format and lint fixes`.
 3. If the final test suite fails, identify which combination of updates caused the interaction and report it to the user.
 
 ## Step 9: Cleanup and Summary


### PR DESCRIPTION
## Summary

- Add `update-deps` skill: a hybrid orchestrator that updates project dependencies safely
- Checks open bot PRs (dependabot, renovate, snyk) for CVE-required patches
- Applies safe minor/patch updates in batch, researches and fixes breaking changes for major bumps via parallel sub-agents
- Supports optional scope filtering (frontend|backend|infra|all) and a `major` flag for full upgrades
- Includes design spec and implementation plan

## Changes

- `skills/update-deps/SKILL.md` (402 lines): Complete skill with 9 steps, sub-agent prompt template, edge cases, and rules
- `docs/superpowers/specs/2026-04-19-update-deps-design.md`: Design spec documenting architecture decisions
- `docs/superpowers/plans/2026-04-19-update-deps.md`: Implementation plan with 7 tasks