### PR TITLE
chore: update plugin metadata with new skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-toolkit",
-  "description": "A collection of skills for agentic coding tools: next-ticket, architect-planner, product-planner, get-it-right, code-review, pr, ship, convert-worktree",
+  "description": "A collection of skills for agentic coding tools: next-ticket, get-it-right, code-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps",
   "version": "0.1.0",
   "author": {
     "name": "Adam Caviness"
@@ -14,6 +14,8 @@
     "planning",
     "code-review",
     "workflows",
-    "worktree"
+    "worktree",
+    "triage",
+    "dependencies"
   ]
 }


### PR DESCRIPTION
## Summary

- Update plugin description to list all current skills (removed stale architect-planner and product-planner, added triage family and update-deps)
- Add `triage` and `dependencies` keywords