### PR TITLE
fix(skill): fix bot PR detection in update-deps

### DIFF
--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -64,6 +64,17 @@ If no manifests match the requested scope, tell the user and stop.
 
 Using whatever CLI is available (e.g., `gh pr list`), fetch open PRs authored by known dependency bots: `dependabot`, `renovate`, `snyk-bot`, `greenkeeper`.
 
+**Important**: `gh pr list --author` accepts only a single value. You MUST run a separate query per bot and merge the results. Note that `dependabot`, `renovate`, and `greenkeeper` are GitHub Apps (use the `app/` prefix), while `snyk-bot` is a regular GitHub user account (no prefix).
+
+```bash
+(
+  gh pr list --author "app/dependabot" --state open --json number,title,author,body 2>/dev/null
+  gh pr list --author "app/renovate" --state open --json number,title,author,body 2>/dev/null
+  gh pr list --author "snyk-bot" --state open --json number,title,author,body 2>/dev/null
+  gh pr list --author "app/greenkeeper" --state open --json number,title,author,body 2>/dev/null
+) | jq -s 'add // []'
+```
+
 For each bot PR:
 
 1. Extract the dependency name and target version from the PR title or body.


### PR DESCRIPTION
## Summary
- `gh pr list --author` only accepts a single string value; passing multiple `--author` flags silently uses only the last one
- Step 2 now runs a separate query per bot and merges results via `jq -s 'add // []'`
- Corrects `app/snyk-bot` to `snyk-bot` since snyk-bot is a regular GitHub user account, not a GitHub App

## Context
Discovered when running `/update-deps` against a repo with 2 open dependabot security PRs. The skill reported "No bot PRs found" because only `greenkeeper[bot]` (the last `--author` flag) was queried.