### PR TITLE
chore(ci): auto-merge release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Auto-merge release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_number=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.number')
+          gh pr merge "$pr_number" --auto --squash --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Adds auto-merge step to the release-please workflow
- Uses `gh pr merge --auto --squash` so GitHub merges the release PR event-driven when branch protection requirements are satisfied
- No more manually merging release-please PRs after every feature merge