### PR TITLE
feat(next-ticket): team-safe claiming + model-judgement detection

### DIFF
--- a/skills/next-ticket/SKILL.md
+++ b/skills/next-ticket/SKILL.md
@@ -13,17 +13,16 @@ Verify you're in a git repo before starting. If not, tell the user and stop.
 
 ## Step 1: Detect Ticket System
 
-Determine which ticket system this project uses. Check in this order:
+Determine which ticket system this project uses.
 
-1. **Cached config**: Check for a `next-ticket-config.json` file in the system temp directory. It maps project root paths to ticket system names. If the current project has an entry, use that value.
-2. **Auto-detect**: Run `git remote -v` and interpret the host to determine the likely ticket system (e.g., github.com suggests GitHub Issues, bitbucket.org suggests Jira, gitlab.com suggests GitLab Issues, dev.azure.com or visualstudio.com suggests Azure Boards).
-3. **Ask the user**: If auto-detect fails, ask: "What ticket system does this project use?" Accept a free-form answer (e.g., "jira", "github issues", "linear", "shortcut").
+1. **Cached config (always wins)**: Check `next-ticket-config.json` in the system temp directory. It maps project root paths to ticket system names. If the current project has an entry, use it and skip straight to Step 1b — never re-detect when the cache has an answer.
+2. **Model-judgement detection**: Use your own judgement on whatever signals the repo happens to provide. Different teams hint at their tracker in different places and different formats — so there is no prescribed file or key to look for. Read whatever seems informative: the README, CLAUDE.md, CONTRIBUTING.md, issue templates, `docs/`, the git remotes, URLs anywhere in the repo, prose mentions of ticket-ID shapes (`PROJ-42`, `#42`, `AB#42`), commit message conventions, CI config references, etc. Lean on model intelligence; don't follow a rigid ladder.
+3. **Confirm with the user.** Tell them what you concluded and where the evidence came from, e.g., "Detected ticket system: Jira (acme.atlassian.net link in README.md). Correct?" If they confirm, cache it. If they correct, cache the correction.
+4. **Can't tell?** Ask plainly: "What ticket system does this project use?" Accept a free-form answer (e.g., "jira", "github issues", "linear", "shortcut"), then cache.
 
-Once determined, cache the value in `next-ticket-config.json` in the system temp directory, keyed by project root path. Create the file if it doesn't exist. Merge with existing entries if it does.
+Cache writes go to `next-ticket-config.json` in the system temp directory, keyed by project root path. Create the file if it doesn't exist. Merge with existing entries; never overwrite unrelated keys.
 
-Confirm the detected system to the user (e.g., "Detected ticket system: GitHub Issues"). If the user corrects it, update the cached value and proceed with their answer.
-
-> **Tip**: If auto-detect consistently gets it wrong for a project (e.g., a GitHub-hosted repo that uses Jira), add `ticketSystem: jira` to the project's CLAUDE.md to skip detection.
+After run 1, the cached value makes detection effectively 100% reliable on subsequent runs — teams are not forced to adopt any particular file, key, or format.
 
 ## Step 1b: Establish User Identity
 

--- a/skills/next-ticket/SKILL.md
+++ b/skills/next-ticket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: next-ticket
-description: Use when looking for the next ticket to work on. Detects the project's ticket system (GitHub Issues, Jira, GitLab Issues, Azure Boards, etc.), fetches all open tickets, scores by severity/simplicity/value/blocking-power/dependencies, picks the best candidate, branches, implements, tests, formats, and waits for review with a UI testing tip.
+description: Use when looking for the next ticket to work on. Detects the project's ticket system (GitHub Issues, Jira, GitLab Issues, Azure Boards, etc.), fetches open tickets that are unassigned or assigned to you, scores by severity/simplicity/value/blocking-power/dependencies, picks the best candidate, claims it by self-assigning (team-safe), branches, implements, tests, formats, and waits for review with a UI testing tip.
 ---
 
 # Next Ticket
@@ -25,15 +25,44 @@ Confirm the detected system to the user (e.g., "Detected ticket system: GitHub I
 
 > **Tip**: If auto-detect consistently gets it wrong for a project (e.g., a GitHub-hosted repo that uses Jira), add `ticketSystem: jira` to the project's CLAUDE.md to skip detection.
 
-## Step 2: Fetch All Open Tickets
+## Step 1b: Establish User Identity
 
-Using whatever CLI tools, MCP tools, or APIs are available in the current session, fetch all open tickets from the detected system.
+The skill claims tickets by assigning them to the person running it, so it needs to know who that is. Identity lives in the same `next-ticket-config.json` under a top-level `__user__` key that sits alongside the project-path entries:
+
+```json
+{
+  "__user__": {
+    "name": "Adam",
+    "usernames": {
+      "github": "adamcaviness",
+      "jira": "adam.caviness@company.com",
+      "gitlab": "acaviness"
+    }
+  },
+  "/home/user/repo-a": "github",
+  "/home/user/repo-b": "jira"
+}
+```
+
+`usernames` is a free-form map keyed by ticket-system name. For environments where one person has multiple handles across hosts (e.g., github.com vs. a self-hosted GHE), use `<system>:<host>` as the key (e.g., `github:ghe.acme.com`). Real project paths always start with `/` or a Windows drive letter, so `__user__` never collides with a path entry.
+
+Resolve identity in this order:
+
+1. **Name**: Read `__user__.name`. If missing, discover it using whatever the session offers — `git config user.name` is usually enough. Only ask the user if discovery turns up nothing.
+2. **Per-system handle**: Read `__user__.usernames[<detectedSystem>]`. If missing, use your own judgement and whatever CLI, MCP, or API tooling is available in this session to discover the user's handle on the detected system. The right command varies by system and by what's installed — don't follow a prescribed recipe; pick the most direct path available. Only prompt the user as a last resort.
+3. **Persist**: Merge the resolved values back into `next-ticket-config.json`. Preserve all existing keys.
+
+If the per-system handle cannot be resolved — discovery fails and the user declines to supply one — stop with a clear message. Running without identity on a shared repo recreates the exact collision this skill is meant to prevent; there is no safe silent fallback.
+
+## Step 2: Fetch Open Tickets
+
+Using whatever CLI tools, MCP tools, or APIs are available in the current session, fetch open tickets that are **either unassigned or assigned to the current user's per-system handle** from Step 1b. Prefer the system's native server-side filter; fall back to fetching all open tickets and filtering locally against the stored handle.
 
 **Common tools by platform:**
-- GitHub Issues: `gh issue list`
-- Jira: `jira` CLI, Atlassian MCP tools, or REST API via `curl`
-- GitLab Issues: `glab issue list`
-- Azure Boards: `az boards work-item list`
+- GitHub Issues: `gh issue list`. Note: `gh issue list --search` combines terms with AND, not OR, so "unassigned OR assigned to me" needs two queries (`no:assignee` and `assignee:@me`) merged by ID.
+- Jira: `jira` CLI, Atlassian MCP tools, or REST API via `curl`. JQL expresses the filter directly: `assignee = currentUser() OR assignee is EMPTY`.
+- GitLab Issues: `glab issue list`. `--assignee=@me` plus an unassigned query, merged by ID.
+- Azure Boards: `az boards work-item list` with a WIQL filter using `@Me` and `[System.AssignedTo] = ''`.
 - Other: Use whatever is available. If no tool is found, tell the user what to install and stop.
 
 Normalize the fetched data into this shape (write to a temp file):
@@ -69,13 +98,13 @@ Read every ticket's title, full body, labels, and comments. Build a mental score
 | **Blocking power** | High | Does this ticket's body or comments mention it blocks other tickets? Are other tickets referencing this one as a dependency? Prefer prereqs. |
 | **Value** | Medium | Is this foundational (auth, data model, core flow)? Or cosmetic? Foundational work compounds. |
 | **Dependencies** | Eliminates | If the ticket explicitly depends on another open ticket, skip it. |
-| **Assignee** | Eliminates | If already assigned to someone, skip it. |
+| **Assignee** | Eliminates | If assigned to someone other than you, skip it. Unassigned and already-yours are both eligible. |
 | **Age** | Low | Older tickets are slightly preferred (avoid starvation). |
 | **Clarity** | Medium | Is the problem well-defined with evidence and a suggested fix? Vague tickets are riskier for AFK implementation. |
 
 ### Decision Process
 
-1. **Eliminate** tickets that have unmet dependencies on other open tickets, or are assigned.
+1. **Eliminate** tickets that have unmet dependencies on other open tickets, or are assigned to someone other than you.
 2. **Rank** remaining tickets. Severity and simplicity dominate. Blocking power breaks ties.
 3. **Pick the top candidate.** If two tickets are very close, prefer the simpler one (higher confidence of correct AFK implementation).
 
@@ -86,6 +115,7 @@ Print a brief rationale, formatting the ticket ID according to the platform (e.g
 ```
 Selected: <ticket-id> - "Fix auth token refresh race condition"
   Severity: high | Simplicity: focused (single file) | Blocks: <id>, <id>
+  Assignee: unassigned | already yours
   Reason: Highest severity, clear fix direction, unblocks two other tickets.
 ```
 
@@ -106,6 +136,18 @@ Before branching, verify the selected ticket is still valid on the latest codeba
      - **Work on it**: If the remaining work is a good candidate (simple, high-value), proceed to Step 5.
      - **Refine and skip**: If you'd rather pick a different ticket, do NOT close this one. Instead, edit the ticket body to remove completed items (keep only remaining work), update the title to reflect the narrower scope, add a comment summarizing what was already done, then loop back to Step 3. The refined ticket becomes eligible for future iterations.
    - **Can't determine**: proceed with caution and note uncertainty.
+
+> **Do not claim during a refine-and-skip pass.** Claiming happens once, in Step 4.5, on the final selection only.
+
+## Step 4.5: Claim the Ticket
+
+Before branching or writing code, self-assign the selected ticket in the source system. This is the point where work becomes visible to teammates and where a last-second race check cuts the chance of two people picking the same ticket.
+
+1. **Re-read the assignee.** Fetch the selected ticket's current assignee from the source system — a fresh read, not cached data from Step 2. A brief randomised pause (0-500ms) before the read helps desynchronise two teammates running simultaneously.
+2. **Foreign-owned now?** If the ticket has just been assigned to someone else, abandon this candidate, note it in one line, and loop back to Step 3 to pick the next.
+3. **Unassigned?** Self-assign using the handle stored under `__user__.usernames[<system>]`. Use whatever CLI, MCP, or API tooling fits the system (e.g., `gh issue edit <id> --add-assignee <handle>` for GitHub). Then read the ticket back once and confirm the assignee matches your handle. If the read-back shows someone else, treat it as a lost race and loop back to Step 3.
+4. **Already yours?** Skip the write. Proceed.
+5. **Assignment failed?** If the tool is missing, permissions are denied, or the write errors out, stop with a clear, specific message. Do not start work on a ticket you couldn't claim.
 
 ## Step 5: Create Branch
 
@@ -178,9 +220,11 @@ The UI testing tip must be **specific and actionable**, not "test the feature" b
 
 - **Never push or create PRs.** The user reviews first.
 - **Never skip tests.** AFK implementation demands high confidence.
-- **Never pick an assigned ticket.** Someone else is working on it.
+- **Never pick a ticket assigned to someone else.** Unassigned and already-yours are both eligible; anything with another person on it is off-limits.
 - **Never pick a ticket with unmet dependencies.** It can't be completed.
+- **Claim after validating, before branching.** Step 4.5 is the only claim point. Re-read the assignee at the top of it so the race window stays small, and don't claim during a Step 4 refine-and-skip pass.
+- **No identity, no run.** If the per-system handle can't be resolved and the user won't supply one, stop. Running unfiltered on a shared repo recreates the collision this skill is meant to prevent.
 - **Validation (Step 4): refine, don't close.** If a ticket has remaining work, edit the ticket to reflect only what remains (update title and body), then move to the next candidate. Never close a ticket that isn't 100% resolved.
 - **Implementation (Steps 5-9): fully implement.** Once you pick a ticket, complete it entirely. No partial commits, no WIP commits, no handoffs. The scoring in Step 3 filters for simplicity and clarity precisely so that picked tickets can be fully implemented touch-free.
-- **If no suitable ticket exists** (all assigned, all blocked, none clear enough for AFK), tell the user and stop.
+- **If no suitable ticket exists** (all assigned to others, all blocked, none clear enough for AFK), tell the user and stop.
 - **Clean up temp files** when done.


### PR DESCRIPTION
## Summary

- **Team-safe claiming** (`d464583`): add per-user identity under a `__user__` key in `next-ticket-config.json` (name + per-system handles), filter fetched tickets to "unassigned OR assigned to me", and self-assign the selected ticket in a new Step 4.5 with a fresh assignee re-read to shrink the simultaneous-pick race window. Username discovery is delegated to model judgement rather than prescribed per-system commands. The `__user__` sentinel key leaves the path-keyed lookup used by the `triage-*` skills untouched.
- **Model-judgement detection** (`1347abc`): replace Step 1's rigid three-step ladder and the prescriptive `ticketSystem: jira` CLAUDE.md tip with cache-first-then-model-judgement. The model reads whatever signals the repo happens to offer (README, CLAUDE.md, CONTRIBUTING.md, docs, git remotes, URLs, ticket-ID shapes, CI config), confirms the conclusion with the user, and caches. Cache always wins. Fallback is asking the user plainly. Teams are not forced to adopt any particular file, key, or format.

## Test plan

- [ ] Fresh run, no config: skill detects system via model judgement, asks for confirmation, caches `__user__` + project entry.
- [ ] Cache hit: subsequent runs skip detection entirely (cache always wins).
- [ ] README URL hint (e.g., `acme.atlassian.net`): model names Jira and cites the link as evidence.
- [ ] No signal in repo: model asks the user plainly.
- [ ] Correction path: user corrects a wrong guess, correction is cached, run 2 is silent.
- [ ] Fetch filter: only unassigned + assigned-to-me tickets appear in the candidate set.
- [ ] Claim race: manually assign the top pick to another user between "Selected…" and Step 4.5; skill detects the foreign assignee on re-read and loops back to Step 3.
- [ ] Already-mine path: pre-assigned-to-self ticket is eligible, selected, and the reassignment write is skipped.
- [ ] Identity unresolvable: if the per-system handle can't be derived and the user declines to supply one, skill stops cleanly instead of running unfiltered.
- [ ] Back-compat: `triage-*` skills still resolve ticket system via path key when `__user__` is present in the config file.
- [ ] No prescribed format: grepping the updated SKILL.md confirms no required file or key is imposed on teams.

https://claude.ai/code/session_017wyH1nwJXbXUAykcvcBg8p

---
_Generated by [Claude Code](https://claude.ai/code/session_017wyH1nwJXbXUAykcvcBg8p)_