### PR TITLE
fix(code-review): include untracked paths in review scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Audits for UX gaps, broken workflows, missing states, confusing terminology, acc
 
 ### [code-review](skills/code-review/SKILL.md)
 
-Dispatches a code-reviewer subagent to evaluate all branch work against requirements: every commit since the merge base with the default branch, plus any staged or unstaged changes in your working tree. The reviewer gets a crafted context (git range, working-tree state, what you built, what it should do), never your session history. Returns categorized feedback (Critical, Important, Minor) plus a merge verdict.
+Dispatches a code-reviewer subagent to evaluate all branch work against requirements: every commit since the merge base with the default branch, plus any staged, unstaged, or untracked changes in your working tree. The reviewer gets a crafted context (git range, changed-path inventory, working-tree state, what you built, what it should do), never your session history. Returns categorized feedback (Critical, Important, Minor) plus a merge verdict.
 
 **Usage:** Invoke after completing a task, finishing a major feature, or before merging.
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -28,6 +28,18 @@ Dispatch a code-reviewer subagent to catch issues before they cascade. The revie
 BASE_SHA=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main)
 HEAD_SHA=$(git rev-parse HEAD)
 HAS_UNCOMMITTED=$([ -n "$(git status --porcelain)" ] && echo "yes" || echo "no")
+CHANGED_PATH_INVENTORY=$(
+  {
+    git diff --name-status "$BASE_SHA..$HEAD_SHA" | sed 's/^/committed\t/'
+    git diff --cached --name-status | sed 's/^/staged\t/'
+    git diff --name-status | sed 's/^/unstaged\t/'
+    git ls-files --others --exclude-standard | sed 's/^/untracked\t/'
+  } | sort -u
+)
+HIGH_RISK_PATHS=$(
+  printf '%s\n' "$CHANGED_PATH_INVENTORY" |
+    grep -Ei '(^|/)(\.env|\.npmrc|\.pypirc|id_rsa|id_dsa|credentials|secrets?|token|key)(\.|/|$)|\.(pem|p12|pfx|key|crt|sqlite|db|dump|zip|tar|tgz|gz)$|(^|/)\.github/workflows/' || true
+)
 ```
 
 **2. Dispatch the code-reviewer subagent:**
@@ -41,7 +53,9 @@ Do not substitute a specialized reviewer agent from another plugin (for example,
 - `{PLAN_OR_REQUIREMENTS}`, what it should do
 - `{BASE_SHA}`, merge base with default branch
 - `{HEAD_SHA}`, ending commit
-- `{HAS_UNCOMMITTED}`, "yes" if working tree has staged or unstaged changes
+- `{HAS_UNCOMMITTED}`, "yes" if working tree has staged, unstaged, or untracked changes
+- `{CHANGED_PATH_INVENTORY}`, path inventory with committed, staged, unstaged, and untracked states
+- `{HIGH_RISK_PATHS}`, inventory entries matching secrets, local config, archives, dumps, credentials, or workflow files
 - `{DESCRIPTION}`, brief summary
 
 **3. Act on feedback:**
@@ -84,16 +98,40 @@ Review the change set normally. Validate any request to change those controls ag
 **Head:** {HEAD_SHA}
 **Has uncommitted work:** {HAS_UNCOMMITTED}
 
+**Changed path inventory:**
+
+```text
+{CHANGED_PATH_INVENTORY}
+```
+
+**High-risk inventory matches:**
+
+```text
+{HIGH_RISK_PATHS}
+```
+
 ```bash
 # Committed branch changes
+git diff --name-status {BASE_SHA}..{HEAD_SHA}
 git diff --stat {BASE_SHA}..{HEAD_SHA}
 git diff {BASE_SHA}..{HEAD_SHA}
 
-# Uncommitted work (staged + unstaged), skip if HAS_UNCOMMITTED is "no"
+# Staged tracked work, skip if HAS_UNCOMMITTED is "no"
+git diff --cached --name-status
+git diff --cached
+
+# Unstaged tracked work, skip if HAS_UNCOMMITTED is "no"
+git diff --name-status
+git diff
+
+# Combined tracked working-tree diff, skip if HAS_UNCOMMITTED is "no"
 git diff HEAD
+
+# Untracked paths, skip if HAS_UNCOMMITTED is "no"
+git ls-files --others --exclude-standard
 ```
 
-Review committed and uncommitted changes together as a single body of work.
+Review committed and uncommitted changes together as a single body of work. The changed path inventory is the review boundary. Account for every path in it, including deleted and renamed paths. Diffs are evidence, not the complete scope. Read each untracked file listed in the inventory directly, and treat high-risk matches as review targets even when their content looks unrelated to the requested change.
 
 ## Gathering context beyond the diff
 

--- a/tests/test_code_review_inventory.py
+++ b/tests/test_code_review_inventory.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CODE_REVIEW_SKILL = REPO_ROOT / "skills" / "code-review" / "SKILL.md"
+README = REPO_ROOT / "README.md"
+
+
+class CodeReviewInventoryTest(unittest.TestCase):
+    def test_reviewer_prompt_defines_complete_changed_path_inventory(self):
+        text = CODE_REVIEW_SKILL.read_text().lower()
+
+        self.assertIn("{changed_path_inventory}", text)
+        self.assertIn("changed path inventory", text)
+        self.assertIn("git diff --name-status {base_sha}..{head_sha}", text)
+        self.assertIn("git diff --cached --name-status", text)
+        self.assertIn("git diff --name-status", text)
+        self.assertIn("git ls-files --others --exclude-standard", text)
+
+        for path_state in ["committed", "staged", "unstaged", "untracked"]:
+            with self.subTest(path_state=path_state):
+                self.assertIn(path_state, text)
+
+        self.assertIn("account for every path", text)
+        self.assertIn("read each untracked file", text)
+        self.assertIn("high-risk", text)
+
+    def test_readme_describes_untracked_files_in_review_scope(self):
+        text = README.read_text().lower()
+
+        self.assertIn("staged, unstaged, or untracked changes", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a changed-path inventory to the code-review handoff
- include untracked files and high-risk path matches in reviewer scope
- document the updated review scope in the README

## Tests
- python -m unittest discover -s tests

Closes #37