### PR TITLE
refactor(skills): centralize branch lifecycle contract (#27)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,19 @@ Every `skills/<name>/` is public API. All three harnesses discover the same `SKI
 
 Never duplicate a skill into a harness-specific subtree. All three harnesses auto-discover `skills/<name>/SKILL.md`. The `model` frontmatter key is honored by Claude Code and ignored by Codex and Gemini.
 
+## Branch lifecycle
+
+Workflow skills that compare against, sync with, or guard the default branch share one contract. Resolve the default branch into `BASE_BRANCH` with this snippet, then use `$BASE_BRANCH` in every command and prose mention:
+
+```bash
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+if [ -z "$BASE_BRANCH" ]; then
+  git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+fi
+```
+
+Never hardcode `main` or `master` in skill commands, guards, diff ranges, or user-facing wording. Use "default branch" in prose. The ahead-of-base check is `git rev-list --count "$BASE_BRANCH..HEAD"`. The diff range for a feature branch is `"$BASE_BRANCH"...HEAD`. The post-merge sync is `git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"`. Skills that document the resolved default branch back to the user should print `$BASE_BRANCH`, not the literal word `main`.
+
 ## Commits and releases
 
 - Only `feat:` (minor) and `fix:` (patch) drive a release PR. Other conventional types are silently ignored by release-please for bump purposes. Use `feat(skill):` scopes to classify new skills.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ if [ -z "$BASE_BRANCH" ]; then
 fi
 ```
 
-Never hardcode `main` or `master` in skill commands, guards, diff ranges, or user-facing wording. Use "default branch" in prose. The ahead-of-base check is `git rev-list --count "$BASE_BRANCH..HEAD"`. The diff range for a feature branch is `"$BASE_BRANCH"...HEAD`. The post-merge sync is `git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"`. Skills that document the resolved default branch back to the user should print `$BASE_BRANCH`, not the literal word `main`.
+Never hardcode `main` or `master` in skill commands, guards, diff ranges, or user-facing wording. Use "default branch" in prose. The ahead-of-base check is `git rev-list --count "$BASE_BRANCH..HEAD"`. The diff range for a feature branch is `"$BASE_BRANCH"...HEAD`. The post-merge sync is `git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"`. The remote-tracking reference is `"origin/$BASE_BRANCH"`. Skills that document the resolved default branch back to the user should print `$BASE_BRANCH`, not the literal word `main`.
+
+Shell state does not persist between separate Bash tool invocations. Each skill must either re-resolve `BASE_BRANCH` at the top of every bash block that consumes it, or substitute the resolved literal branch name into the commands the agent runs (instead of letting `$BASE_BRANCH` expand in a fresh shell where it is unset). Do not assume a variable set in step N is still in scope in step N+1.
 
 ## Commits and releases
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A collection of skills for agentic coding tools, including [Claude Code](https:/
 | **Quality** | [code-review](#code-review) | `/code-review` | Dispatch a reviewer subagent to evaluate all branch work (committed + uncommitted) |
 | | [get-it-right](#get-it-right) | `/get-it-right` | Re-architect the current branch from scratch, leave unstaged for review |
 | **Workflow** | [pr](#pr) | `/pr` | Format, lint, test, commit, push, open PR |
-| | [ship](#ship) | `/ship` | Commit, push, merge PR, sync main, delete branch |
+| | [ship](#ship) | `/ship` | Commit, push, merge PR, sync default branch, delete branch |
 | | [convert-worktree](#convert-worktree) | `/convert-worktree` | Cleanly convert a worktree back into a local branch |
 | **Utility** | [compress-markdown](#compress-markdown) | `/compress-markdown` | Compress markdown to save tokens; `deep` validates against codebase first |
 | | [update-deps](#update-deps) | `/update-deps` | Check CVEs, apply minor/patch updates, `major` for breaking changes; scopeable |
@@ -138,7 +138,7 @@ The "I'm done" command. Runs format/lint and tests (skips if already passing wit
 
 ### [ship](skills/ship/SKILL.md)
 
-The complete branch lifecycle. Commits, pushes, creates or updates a PR, merges it, syncs local main, and deletes the branch. The skill detects your repo's allowed merge strategies (merge, squash, rebase) and caches the policy in `.git/agents/repo-policy.json` with a 30-day freshness window, retrying once on policy errors. For forked repos, PRs always target your fork, never upstream.
+The complete branch lifecycle. Commits, pushes, creates or updates a PR, merges it, syncs the local default branch, and deletes the branch. The skill detects your repo's allowed merge strategies (merge, squash, rebase) and caches the policy in `.git/agents/repo-policy.json` with a 30-day freshness window, retrying once on policy errors. For forked repos, PRs always target your fork, never upstream.
 
 **Usage:** `/ship`
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -14,7 +14,7 @@ Dispatch a code-reviewer subagent to catch issues before they cascade. The revie
 **Mandatory:**
 - After each task in multi-task development
 - After completing a major feature
-- Before merge to main
+- Before merge to the default branch
 
 **Optional but valuable:**
 - When stuck (fresh perspective)
@@ -25,7 +25,11 @@ Dispatch a code-reviewer subagent to catch issues before they cascade. The revie
 
 **1. Get git range:**
 ```bash
-BASE_SHA=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main)
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+if [ -z "$BASE_BRANCH" ]; then
+  git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+fi
+BASE_SHA=$(git merge-base HEAD "origin/$BASE_BRANCH" 2>/dev/null || git merge-base HEAD "$BASE_BRANCH")
 HEAD_SHA=$(git rev-parse HEAD)
 HAS_UNCOMMITTED=$([ -n "$(git status --porcelain)" ] && echo "yes" || echo "no")
 CHANGED_PATH_INVENTORY=$(
@@ -277,7 +281,7 @@ If the project has a verification command, run it and include the outcome. Look 
 
 You: Let me request code review before proceeding.
 
-BASE_SHA=$(git merge-base HEAD origin/main)
+BASE_SHA=$(git merge-base HEAD "origin/$BASE_BRANCH")
 HEAD_SHA=$(git rev-parse HEAD)
 
 [Dispatch general-purpose subagent with reviewer prompt]

--- a/skills/convert-worktree/SKILL.md
+++ b/skills/convert-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: convert-worktree
-description: Convert a git worktree into a local branch. Rebase onto latest main, clean up project resources, remove worktree, checkout branch in main workspace. Use when finishing work in a worktree.
+description: Convert a git worktree into a local branch. Rebase onto latest default branch, clean up project resources, remove worktree, checkout branch in main workspace. Use when finishing work in a worktree.
 disable-model-invocation: true
 ---
 
@@ -34,10 +34,9 @@ fi
 WORKTREE_PATH=$(pwd)
 ```
 
-Detect the base branch dynamically:
+Resolve the default branch using the shared branch lifecycle contract from AGENTS.md:
 ```bash
 BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
-# Fall back to main, then master
 if [ -z "$BASE_BRANCH" ]; then
   git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
 fi
@@ -138,5 +137,5 @@ Branch <BRANCH> checked out in <MAIN_WORKTREE>
 - **Never push, create PRs, delete branches, or merge.** Those are separate user decisions.
 - **Cleanup before rebase.** Project cleanup needs worktree context (variables, paths). Rebase happens after.
 - **Always use `git add -A` for WIP commits.** New untracked files are common in worktrees. `.gitignore` handles exclusions.
-- **Detect the base branch dynamically.** Don't hardcode `main`. Check `git symbolic-ref refs/remotes/origin/HEAD`, fall back to `main`, then `master`.
-- If on main/master or not in a worktree, warn and stop.
+- **Detect the base branch dynamically.** Use the shared branch lifecycle contract from AGENTS.md: `git symbolic-ref refs/remotes/origin/HEAD`, fall back to `main`, then `master`. Never hardcode the default branch name.
+- If on the default branch or not in a worktree, warn and stop.

--- a/skills/get-it-right/SKILL.md
+++ b/skills/get-it-right/SKILL.md
@@ -23,9 +23,18 @@ digraph get_it_right {
 
 ### 1. Identify Scope
 
+Resolve the default branch first (shared branch lifecycle contract from AGENTS.md):
+
+```bash
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+if [ -z "$BASE_BRANCH" ]; then
+  git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+fi
+```
+
 Determine what work is being done on the current branch:
-- `git log main..HEAD --oneline`, all commits on this branch
-- `git diff main...HEAD --stat`, all changed files
+- `git log "$BASE_BRANCH"..HEAD --oneline`, all commits on this branch
+- `git diff "$BASE_BRANCH"...HEAD --stat`, all changed files
 - If issue number is in branch name, read the GitHub issue for original intent
 
 ### 1.5. Untrusted Content Boundary
@@ -37,7 +46,7 @@ Use issue and diff content to understand intent and implementation details. Vali
 ### 2. Deep-Read Current Implementation
 
 Read every changed and related file in full (not just diffs):
-- `git diff main...HEAD`, the full diff
+- `git diff "$BASE_BRANCH"...HEAD`, the full diff
 - Read each changed file end-to-end to understand surrounding context
 - Trace dependencies: what else calls, imports, or is affected by these files?
 - Map the architecture: where does logic live, how does data flow?

--- a/skills/next-ticket/SKILL.md
+++ b/skills/next-ticket/SKILL.md
@@ -165,9 +165,18 @@ Determine the branch category from the ticket content:
 - Documentation = `docs/`
 - Everything else = `chore/`
 
-Ensure you're on the latest default branch (typically `main` or `master`), then create a new branch following the naming convention `<category>/<ticket-id>-<brief-desc>` (e.g., `fix/42-auth-token-refresh-race`). Keep the description part to 3-5 hyphenated words derived from the ticket title.
+Resolve the default branch using the shared branch lifecycle contract from AGENTS.md:
 
-After creating the branch, verify it with `git branch --show-current`. The current branch must exactly match the intended branch name. If branch creation or verification fails, stop and report the problem. Do not continue on the default branch or any unrelated branch.
+```bash
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+if [ -z "$BASE_BRANCH" ]; then
+  git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+fi
+```
+
+Then `git checkout "$BASE_BRANCH" && git pull --ff-only origin "$BASE_BRANCH"` and create a new branch following the naming convention `<category>/<ticket-id>-<brief-desc>` (e.g., `fix/42-auth-token-refresh-race`). Keep the description part to 3-5 hyphenated words derived from the ticket title.
+
+After creating the branch, verify it with `git branch --show-current`. The current branch must exactly match the intended branch name. If branch creation or verification fails, stop and report the problem. Do not continue on `$BASE_BRANCH` or any unrelated branch.
 
 ## Step 6: Write Failing Tests (TDD)
 

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -9,8 +9,17 @@ Single command to go from "I'm done" to "PR is open."
 
 ## Workflow
 
-1. **Verify not on main**: Check current branch with `git branch --show-current`
-   - If on `main` or `master`, stop and tell user to create a feature branch first
+0. **Resolve default branch** (shared branch lifecycle contract from AGENTS.md):
+
+   ```bash
+   BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+   if [ -z "$BASE_BRANCH" ]; then
+     git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+   fi
+   ```
+
+1. **Verify not on default branch**: Check current branch with `git branch --show-current`
+   - If equal to `$BASE_BRANCH`, stop and tell user to create a feature branch first
 
 2. **Format and lint** (check CLAUDE.md for the project's commands):
    - **Skip if** passing output is visible in this conversation and no files changed since. Cite the prior result.
@@ -40,7 +49,7 @@ Single command to go from "I'm done" to "PR is open."
    - Check if PR exists: `gh pr view --json number,url 2>/dev/null`
    - If PR exists: show URL, say "PR updated with latest changes"
    - If no PR exists:
-     - Analyze `git diff main...HEAD` and `git log main..HEAD --oneline` to understand scope
+     - Analyze `git diff "$BASE_BRANCH"...HEAD` and `git log "$BASE_BRANCH"..HEAD --oneline` to understand scope
      - Create PR with `gh pr create`:
        - Concise title (under 70 chars, conventional commit style)
        - Body:
@@ -62,8 +71,8 @@ Single command to go from "I'm done" to "PR is open."
 
 ## Error Handling
 
-- **On main branch**: Stop immediately, suggest creating feature branch
-- **No changes AND no commits ahead of main**: Inform user there's nothing to PR
+- **On default branch**: Stop immediately, suggest creating feature branch
+- **No changes AND no commits ahead of `$BASE_BRANCH`**: Inform user there's nothing to PR
 - **Format/lint fails**: Stop, show errors. Cannot push unlinted code.
 - **Tests fail**: Stop, show failures. Cannot push broken code.
 - **Push rejected (behind remote)**: Suggest `git pull --rebase origin <branch>`

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Commit, push, create/merge PR, sync local main, delete branch. The standard "I'm done with this branch" workflow.
+description: Commit, push, create/merge PR, sync local default branch, delete branch. The standard "I'm done with this branch" workflow.
 ---
 
 # Ship
@@ -9,13 +9,22 @@ Complete the current branch by committing, pushing, merging, and cleaning up.
 
 ## Steps
 
+0. **Resolve default branch** (shared branch lifecycle contract from AGENTS.md):
+
+   ```bash
+   BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+   if [ -z "$BASE_BRANCH" ]; then
+     git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+   fi
+   ```
+
 1. **Review uncommitted changes**: Run `git status` and `git diff` to see what's uncommitted. If any files or changes look suspect, prompt the user and wait for confirmation before committing.
 2. **Commit**: Stage and commit the confirmed changes with a descriptive message based on the diff.
 3. **Push**: Push the current branch to origin with `-u` flag if not already pushed.
 4. **Create PR** (if none exists): Create a PR using `gh pr create`. Use commit messages to generate the title and body. For forked repos, use `--repo` targeting the user's fork (origin), never upstream.
 5. **Resolve merge strategy**: Read cached repository policy from `$(git rev-parse --git-dir)/agents/repo-policy.json` if present and fresh. If missing, stale, invalid, or for a different repository, refresh it with `gh repo view --json nameWithOwner,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,deleteBranchOnMerge` and write the result back to the cache.
 6. **Merge PR**: Choose the first allowed strategy in this order: `--merge` when `mergeCommitAllowed` is true, else `--squash` when `squashMergeAllowed` is true, else `--rebase` when `rebaseMergeAllowed` is true. Merge with `gh pr merge <strategy>`. For forked repos, use `--repo` targeting the fork. If no strategy is allowed, stop and report the repository merge policy.
-7. **Sync main**: `git checkout main && git pull origin main`
+7. **Sync default branch**: `git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"`
 8. **Clean up**: Delete the merged branch locally (`git branch -D`). Only delete the remote branch (`git push origin --delete`) if it still exists. Some repos auto-delete branches on merge.
 9. **Report**: Confirm done with the merged PR URL.
 
@@ -46,9 +55,9 @@ Complete the current branch by committing, pushing, merging, and cleaning up.
 ## Rules
 
 - For forked repos (where origin and upstream differ), NEVER create or merge PRs on the upstream repo. Always target the user's fork (origin).
-- If the branch has no commits ahead of main and no uncommitted changes, warn and stop.
+- If the branch has no commits ahead of `$BASE_BRANCH` and no uncommitted changes, warn and stop.
 - If there's an open PR already, push any new commits to update it, then merge it.
 - If the merge fails due to stale repository policy cache, refresh the cache once and retry only with an allowed strategy.
 - If the merge fails for any other reason, report the error. Don't retry or force.
 - Do not bypass failing required checks, conflicts, review requirements, or permissions errors.
-- If on main, warn and stop. Ship only works on feature branches.
+- If on the default branch, warn and stop. Ship only works on feature branches.

--- a/tests/test_branch_lifecycle_contract.py
+++ b/tests/test_branch_lifecycle_contract.py
@@ -15,6 +15,7 @@ LIFECYCLE_REQUIRED_SKILLS = [
     "get-it-right",
     "next-ticket",
     "convert-worktree",
+    "code-review",
 ]
 
 DETECTION_SNIPPET_ELEMENTS = [
@@ -22,25 +23,30 @@ DETECTION_SNIPPET_ELEMENTS = [
     "BASE_BRANCH",
 ]
 
+COMMAND_POSITION_FORBIDDEN = [
+    r"git checkout main\b",
+    r"git pull origin main\b",
+    r"git pull --ff-only origin main\b",
+    r"git fetch origin main\b",
+    r"git merge-base HEAD origin/main\b",
+    r"git merge-base HEAD main\b",
+    r"git diff main\.\.\.HEAD",
+    r"git log main\.\.HEAD",
+]
+
 FORBIDDEN_PATTERNS = {
-    "ship": [
-        r"git checkout main\b",
-        r"git pull origin main\b",
+    "ship": COMMAND_POSITION_FORBIDDEN + [
         r"\bahead of main\b",
         r"\bIf on main\b",
     ],
-    "pr": [
-        r"git diff main\.\.\.HEAD",
-        r"git log main\.\.HEAD",
+    "pr": COMMAND_POSITION_FORBIDDEN + [
         r"on `main` or `master`",
         r"\bahead of main\b",
     ],
-    "get-it-right": [
-        r"git diff main\.\.\.HEAD",
-        r"git log main\.\.HEAD",
-    ],
-    "next-ticket": [],
-    "convert-worktree": [],
+    "get-it-right": COMMAND_POSITION_FORBIDDEN,
+    "next-ticket": COMMAND_POSITION_FORBIDDEN,
+    "convert-worktree": COMMAND_POSITION_FORBIDDEN,
+    "code-review": COMMAND_POSITION_FORBIDDEN,
 }
 
 

--- a/tests/test_branch_lifecycle_contract.py
+++ b/tests/test_branch_lifecycle_contract.py
@@ -1,0 +1,84 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+README = REPO_ROOT / "README.md"
+AGENTS = REPO_ROOT / "AGENTS.md"
+
+
+LIFECYCLE_REQUIRED_SKILLS = [
+    "ship",
+    "pr",
+    "get-it-right",
+    "next-ticket",
+    "convert-worktree",
+]
+
+DETECTION_SNIPPET_ELEMENTS = [
+    "git symbolic-ref refs/remotes/origin/HEAD",
+    "BASE_BRANCH",
+]
+
+FORBIDDEN_PATTERNS = {
+    "ship": [
+        r"git checkout main\b",
+        r"git pull origin main\b",
+        r"\bahead of main\b",
+        r"\bIf on main\b",
+    ],
+    "pr": [
+        r"git diff main\.\.\.HEAD",
+        r"git log main\.\.HEAD",
+        r"on `main` or `master`",
+        r"\bahead of main\b",
+    ],
+    "get-it-right": [
+        r"git diff main\.\.\.HEAD",
+        r"git log main\.\.HEAD",
+    ],
+    "next-ticket": [],
+    "convert-worktree": [],
+}
+
+
+class BranchLifecycleContractTest(unittest.TestCase):
+    def skill_text(self, skill_name):
+        return (SKILLS_DIR / skill_name / "SKILL.md").read_text()
+
+    def test_workflow_skills_include_default_branch_detection(self):
+        for skill_name in LIFECYCLE_REQUIRED_SKILLS:
+            with self.subTest(skill=skill_name):
+                text = self.skill_text(skill_name)
+                for element in DETECTION_SNIPPET_ELEMENTS:
+                    self.assertIn(
+                        element,
+                        text,
+                        f"{skill_name}: missing canonical detection element {element!r}",
+                    )
+
+    def test_workflow_skills_do_not_hardcode_default_branch_name(self):
+        for skill_name, patterns in FORBIDDEN_PATTERNS.items():
+            text = self.skill_text(skill_name)
+            for pattern in patterns:
+                with self.subTest(skill=skill_name, pattern=pattern):
+                    self.assertIsNone(
+                        re.search(pattern, text),
+                        f"{skill_name}: forbidden hardcoded reference matched {pattern!r}",
+                    )
+
+    def test_readme_uses_default_branch_wording_for_workflow_skills(self):
+        text = README.read_text().lower()
+        self.assertNotIn("syncs local main", text)
+        self.assertIn("default branch", text)
+
+    def test_agents_md_documents_branch_lifecycle_contract(self):
+        text = AGENTS.read_text().lower()
+        self.assertIn("branch lifecycle", text)
+        self.assertIn("git symbolic-ref refs/remotes/origin/head", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Centralize default-branch detection across the toolkit's workflow skills. Until this change, `ship`, `pr`, `get-it-right`, `next-ticket`, and `code-review` each hardcoded `main` in `git checkout`, diff/log ranges, ahead-of-base guards, and prose; only `convert-worktree` resolved the default branch dynamically. The result was inconsistent behavior on repos whose default branch is not `main`, and a maintenance hazard whenever lifecycle policy needed to change.

## Changes

- New `Branch lifecycle` section in `AGENTS.md` defines the canonical contract: `BASE_BRANCH` resolution snippet, `origin/$BASE_BRANCH` idiom, ahead-of-base check, diff range, post-merge sync, and an explicit note that shell state does not persist between separate Bash invocations.
- `skills/ship`, `skills/pr`, `skills/get-it-right`, `skills/next-ticket`, and `skills/code-review` route through `BASE_BRANCH` instead of hardcoding `main`. `skills/convert-worktree` (which already detected) now references the shared contract.
- `README.md` updates the ship row and ship description from "main" to "default branch" where it describes generic lifecycle behavior; release-please's "merged to main" reference is intentionally untouched (it describes git convention, not lifecycle).
- `tests/test_branch_lifecycle_contract.py` (new) gates the contract on every future edit: presence of the detection snippet in all six skills, a shared command-position forbidden-pattern set, README wording, and the AGENTS.md contract documentation.

## Testing

- `python3 -m unittest discover tests` passes 13/13.
- Manual sweep for residual hardcoded `main` in lifecycle contexts found no stragglers (excluding the legitimate fallback line `BASE_BRANCH=main` and historical plan docs in `docs/superpowers/plans/`).

Closes #27