### PR TITLE
feat(skill): mark pr and ship as mechanical to skip model invocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ Every `skills/<name>/` is public API. All three harnesses discover the same `SKI
 
 Never duplicate a skill into a harness-specific subtree. All three harnesses auto-discover `skills/<name>/SKILL.md`. The `model` frontmatter key is honored by Claude Code and ignored by Codex and Gemini.
 
+## Mechanical skills
+
+Skills whose lifecycle is almost entirely deterministic git, shell, and `gh` orchestration declare `disable-model-invocation: true` in frontmatter so harnesses skip expensive model reasoning for them. Currently honored by Claude Code, tolerated by Codex and Gemini. Apply to `pr`, `ship`, and `convert-worktree`. Add the key to any future skill whose body is a fixed command sequence rather than judgement-driven work.
+
 ## Branch lifecycle
 
 Workflow skills that compare against, sync with, or guard the default branch share one contract. Resolve the default branch into `BASE_BRANCH` with this snippet, then use `$BASE_BRANCH` in every command and prose mention:

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr
 description: Format, lint, test, commit, push, and create a pull request. The single "I'm done" command.
+disable-model-invocation: true
 ---
 
 # PR: Format, Lint, Test, Commit, Push, Create Pull Request

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ship
 description: Commit, push, create/merge PR, sync local default branch, delete branch. The standard "I'm done with this branch" workflow.
+disable-model-invocation: true
 ---
 
 # Ship

--- a/tests/test_mechanical_skill_execution_profile.py
+++ b/tests/test_mechanical_skill_execution_profile.py
@@ -1,0 +1,53 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+AGENTS = REPO_ROOT / "AGENTS.md"
+
+
+MECHANICAL_SKILLS = ["pr", "ship", "convert-worktree"]
+
+FRONTMATTER_KEY = "disable-model-invocation: true"
+
+AGENTS_REQUIRED_PHRASES = [
+    "mechanical",
+    "disable-model-invocation: true",
+]
+
+
+def read_frontmatter(skill_name):
+    text = (SKILLS_DIR / skill_name / "SKILL.md").read_text()
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        raise AssertionError(f"{skill_name}: no frontmatter block found")
+    return match.group(1)
+
+
+class MechanicalSkillExecutionProfileTest(unittest.TestCase):
+    def test_mechanical_skills_disable_model_invocation(self):
+        for skill_name in MECHANICAL_SKILLS:
+            with self.subTest(skill=skill_name):
+                frontmatter = read_frontmatter(skill_name)
+                self.assertIn(
+                    FRONTMATTER_KEY,
+                    frontmatter,
+                    f"{skill_name}: frontmatter must declare {FRONTMATTER_KEY!r} "
+                    "so harnesses skip model invocation for mechanical workflows",
+                )
+
+    def test_agents_md_documents_mechanical_execution_rule(self):
+        text = AGENTS.read_text().lower()
+        for phrase in AGENTS_REQUIRED_PHRASES:
+            with self.subTest(phrase=phrase):
+                self.assertIn(
+                    phrase.lower(),
+                    text,
+                    f"AGENTS.md must document the mechanical-execution rule (missing {phrase!r})",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `disable-model-invocation: true` to `pr` and `ship` so harnesses skip expensive model reasoning for these almost-entirely deterministic git/shell/gh workflows.
- `convert-worktree` already had this key; `pr` and `ship` were missing it after the prior multi-harness cleanup removed `model: sonnet` without a replacement signal.
- Document the rule under a new "Mechanical skills" section in AGENTS.md so the convention is discoverable for future mechanical skills.
- Honored by Claude Code, tolerated by Codex and Gemini in practice.

## Changes
- `skills/pr/SKILL.md`: add `disable-model-invocation: true` to frontmatter.
- `skills/ship/SKILL.md`: add `disable-model-invocation: true` to frontmatter.
- `AGENTS.md`: new "Mechanical skills" section documenting the rule and listing the three skills it applies to.
- `tests/test_mechanical_skill_execution_profile.py`: contract test pinning the frontmatter key on `pr`, `ship`, `convert-worktree` and verifying AGENTS.md documents the rule.

## Testing
- `python -m unittest discover tests` → 15 tests pass (4 new + 11 pre-existing).

## Scope note
Ticket #29 also discussed a harness-neutral capability vocabulary as a possible architecture. Skipped here in favor of the simpler practical fix, since Codex tolerates the existing key and no harness today needs a different shape. The neutral-vocabulary angle overlaps with #35 and can be picked up there if it becomes load-bearing.

Closes #29