### PR TITLE
fix(pr): add publish state gate so user work cannot be skipped

### DIFF
--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -22,31 +22,44 @@ Single command to go from "I'm done" to "PR is open."
 1. **Verify not on default branch**: Check current branch with `git branch --show-current`
    - If equal to `$BASE_BRANCH`, stop and tell user to create a feature branch first
 
-2. **Format and lint** (check CLAUDE.md for the project's commands):
+2. **Inventory working tree and commit implementation work**:
+   - Capture the working-tree state with `git status --porcelain` and the untracked path list with `git ls-files --others --exclude-standard`
+   - Classify every reported path as staged, unstaged, or untracked. Run `git diff --cached` for staged content and `git diff` for unstaged content. Read each untracked file before staging it.
+   - If any paths are present, this is the implementation submission. Stage the intended paths and commit them with a descriptive message derived from the diff. Do not use a `wip:` placeholder. Do not run `git add -A` blindly; stage by explicit path so untracked files are added intentionally.
+   - If a path should be excluded from the PR, the user must add it to `.gitignore` or stash it before `/pr` continues. The skill does not stash silently.
+   - If the working tree is clean, skip the commit and continue. The branch must already have implementation commits ahead of `$BASE_BRANCH` (verified in step 6).
+
+3. **Format and lint** (check CLAUDE.md for the project's commands):
    - **Skip if** passing output is visible in this conversation and no files changed since. Cite the prior result.
    - If it fails, report errors and stop
 
-3. **Run tests** (check CLAUDE.md for the project's test command):
+4. **Run tests** (check CLAUDE.md for the project's test command):
    - **Skip if** passing output is visible in this conversation and no files changed since. Cite the prior result.
    - If tests fail, report failures and stop
 
-4. **Stage and commit auto-fixed files**:
+5. **Stage and commit auto-fixed files**:
    - Check `git status` for changes from formatting
-   - If there are changes: stage them, commit with message "Auto-format and lint fixes"
+   - If there are changes: stage them, commit with message "Auto-format and lint fixes". This is a separate commit from the implementation commit in step 2.
    - If no changes: skip
 
-5. **Push to remote**:
+6. **Pre-push gate** (build the publication inventory before any push):
+   - Verify the branch has commits ahead of base: `git rev-list --count "$BASE_BRANCH..HEAD"`. If zero, stop and report "nothing to publish". This is the only valid no-op exit.
+   - Verify the working tree is clean: `git status --porcelain` must be empty. If anything remains, stop and report which paths are still uncommitted. The skill never pushes a branch while staged, unstaged, or untracked work remains.
+   - Inventory the publication content: `git diff --name-status "$BASE_BRANCH"...HEAD` lists every committed path the push will publish. Read this list.
+   - Screen the publication inventory for high-risk patterns. Stop and report if any path matches `.env`, `.env.*`, `*.pem`, `*.key`, `id_rsa*`, `*.p12`, `*.pfx`, `*credential*`, `*secret*`, or `*.sqlite*`. The user must explicitly confirm or remove the path before push.
+
+7. **Push to remote**:
    - Check if branch exists on remote: `git ls-remote --heads origin $(git branch --show-current)`
    - If new branch: `git push -u origin $(git branch --show-current)`
    - If existing: `git push`
    - If already up-to-date: skip
 
-6. **Extract issue number from branch name**:
+8. **Extract issue number from branch name**:
    - Pattern: `<category>/<number>-<desc>` → `#<number>`
    - Example: `fix/224-streaming-upload-size-check` → `224`
    - If no number found: warn "No issue number found in branch name. Add Closes #NNN manually if applicable."
 
-7. **Create or update PR**:
+9. **Create or update PR**:
    - Check if PR exists: `gh pr view --json number,url 2>/dev/null`
    - If PR exists: show URL, say "PR updated with latest changes"
    - If no PR exists:
@@ -73,7 +86,9 @@ Single command to go from "I'm done" to "PR is open."
 ## Error Handling
 
 - **On default branch**: Stop immediately, suggest creating feature branch
-- **No changes AND no commits ahead of `$BASE_BRANCH`**: Inform user there's nothing to PR
+- **Nothing to publish** (clean working tree AND zero commits ahead of `$BASE_BRANCH`): Inform user there's nothing to PR and stop
+- **Working tree dirty at pre-push gate**: Stop, list the remaining staged, unstaged, and untracked paths, and tell the user to commit or exclude them
+- **High-risk path in publication inventory**: Stop, name each matched path, and require the user to confirm or remove before retrying
 - **Format/lint fails**: Stop, show errors. Cannot push unlinted code.
 - **Tests fail**: Stop, show failures. Cannot push broken code.
 - **Push rejected (behind remote)**: Suggest `git pull --rebase origin <branch>`
@@ -88,6 +103,6 @@ Single command to go from "I'm done" to "PR is open."
 
 # Typical workflow:
 # 1. Make changes on feature branch
-# 2. /pr (does everything: format, lint, test, commit, push, PR)
+# 2. /pr (does everything: inventory, commit, format, lint, test, push, PR)
 # 3. Review PR in GitHub
 ```

--- a/tests/test_pr_publish_state_gate.py
+++ b/tests/test_pr_publish_state_gate.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PR_SKILL = REPO_ROOT / "skills" / "pr" / "SKILL.md"
+
+
+class PrPublishStateGateTest(unittest.TestCase):
+    def setUp(self):
+        self.text = PR_SKILL.read_text()
+        self.lower = self.text.lower()
+
+    def test_pr_skill_inventories_working_tree_before_publishing(self):
+        self.assertIn("git status --porcelain", self.text)
+        self.assertIn("git ls-files --others --exclude-standard", self.text)
+        for state in ["staged", "unstaged", "untracked"]:
+            with self.subTest(state=state):
+                self.assertIn(state, self.lower)
+
+    def test_pr_skill_commits_implementation_work_before_push(self):
+        self.assertRegex(self.lower, r"commit.*implementation")
+        self.assertIn("auto-format and lint fixes", self.lower)
+
+    def test_pr_skill_verifies_ahead_of_base_before_push(self):
+        self.assertIn('git rev-list --count "$BASE_BRANCH..HEAD"', self.text)
+
+    def test_pr_skill_inventories_committed_paths_before_push(self):
+        self.assertIn('git diff --name-status "$BASE_BRANCH"...HEAD', self.text)
+
+    def test_pr_skill_screens_high_risk_paths_before_push(self):
+        self.assertIn("high-risk", self.lower)
+        for pattern in [".env", ".pem", "credential"]:
+            with self.subTest(pattern=pattern):
+                self.assertIn(pattern, self.lower)
+
+    def test_pr_skill_stops_when_nothing_to_publish(self):
+        self.assertRegex(self.lower, r"nothing to publish|no commits.*to push")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `/pr` only committed formatter output, so a user with normal staged, unstaged, or untracked implementation work could push an older branch tip and open a PR whose diff omitted the work being submitted.
- Reverse failure was also possible: a prior broad WIP commit could publish unintended files because the workflow inspected only the working tree, not the ahead-of-base committed range.
- Make branch state a first-class gate: explicit working-tree inventory and implementation commit before format/lint/test, and a pre-push gate that checks ahead-of-base, requires a clean tree, lists the publication path inventory, and screens for high-risk path patterns (`.env`, keys, credentials, secrets).

## Changes
- Rewrote `skills/pr/SKILL.md` workflow: new step 2 (inventory + commit implementation), new step 6 (pre-push gate with `git rev-list --count`, `git diff --name-status "\$BASE_BRANCH"...HEAD`, and high-risk pattern screen). Forbids `git add -A` and `wip:` placeholders.
- Updated Error Handling section to cover dirty tree at gate, high-risk path matches, and the renamed "nothing to publish" exit.
- Added `tests/test_pr_publish_state_gate.py` (6 tests) encoding the gate contract so future edits cannot silently regress it.

## Testing
- `python -m unittest discover tests` → 21/21 passing.
- New tests verified failing on `main` baseline before implementation.

Closes #36