### PR TITLE
fix(convert-worktree): split preservation from history (#33)

### DIFF
--- a/skills/convert-worktree/SKILL.md
+++ b/skills/convert-worktree/SKILL.md
@@ -44,17 +44,36 @@ fi
 
 Announce: "Converting worktree `<WORKTREE_PATH>` (branch `<BRANCH>`) → main workspace at `<MAIN_WORKTREE>`"
 
-### 2. Commit uncommitted work
+### 2. Preserve uncommitted work
+
+Split preservation from history. Tracked modifications and content the user already staged are committed. Unstaged untracked files are stashed so they survive worktree removal without entering branch history (`.gitignore` is not a secret scanner, and a blanket `git add -A` can promote `.env` files, credentials, generated artifacts, or unrelated scratch into a commit that later workflows publish).
 
 ```bash
-# Check for any changes (staged, unstaged, or untracked)
+# Show what's there before touching anything
+git status --short
+
+STASHED_UNTRACKED=0
 if [ -n "$(git status --porcelain)" ]; then
-  git add -A
-  git commit -m "wip: uncommitted changes from worktree conversion"
+  # Stage tracked modifications and deletions. Anything the user already
+  # staged (including new files they explicitly `git add`ed) stays staged.
+  git add -u
+
+  # Commit if there's anything in the index. Untracked-and-unstaged files
+  # are deliberately not in scope here.
+  if [ -n "$(git diff --cached --name-only)" ]; then
+    git commit -m "wip: tracked changes from worktree conversion"
+  fi
+
+  # Stash any remaining untracked files. The stash ref is repo-level, so it
+  # survives worktree removal and is popped in the main workspace at step 5.
+  if [ -n "$(git ls-files --others --exclude-standard)" ]; then
+    git stash push --include-untracked -m "convert-worktree:untracked:$BRANCH"
+    STASHED_UNTRACKED=1
+  fi
 fi
 ```
 
-`.gitignore` handles exclusions so `git add -A` is safe.
+Capture the untracked paths from `git status --short` for the final report so the user knows exactly what was preserved outside history.
 
 ### 3. Project cleanup
 
@@ -118,6 +137,14 @@ fi
 
 git worktree remove "$WORKTREE_PATH" --force
 git checkout "$BRANCH"
+
+# Restore untracked files from step 2. They reappear as untracked in the
+# main workspace, never entering branch history.
+if [ "$STASHED_UNTRACKED" = "1" ]; then
+  if ! git stash pop; then
+    echo "WARN: could not auto-pop untracked stash. Inspect with 'git stash list'."
+  fi
+fi
 ```
 
 ### 6. Report
@@ -128,6 +155,7 @@ Print a summary:
 Branch <BRANCH> checked out in <MAIN_WORKTREE>
   Rebase: <succeeded | skipped (already up-to-date) | failed (branch is un-rebased)>
   Cleanup: <ran make dev-stop | no cleanup target found | cleanup failed>
+  <If untracked files were stashed: list each path under "Untracked (popped from stash, review before committing):">
   <If lockfiles were auto-resolved: "Run npm install (or equivalent) to update lockfiles">
 ```
 
@@ -136,6 +164,6 @@ Branch <BRANCH> checked out in <MAIN_WORKTREE>
 - **Never block on failure.** Rebase failure, cleanup failure, and lockfile conflicts are all warnings. The conversion always completes.
 - **Never push, create PRs, delete branches, or merge.** Those are separate user decisions.
 - **Cleanup before rebase.** Project cleanup needs worktree context (variables, paths). Rebase happens after.
-- **Always use `git add -A` for WIP commits.** New untracked files are common in worktrees. `.gitignore` handles exclusions.
+- **Never auto-commit untracked files.** Tracked modifications and explicitly staged content go into the WIP commit; unstaged untracked files are stashed and re-popped in the main workspace. `.gitignore` is an exclusion list, not a secret scanner, so a blanket `git add -A` can leak `.env` files, credentials, or generated artifacts into history.
 - **Detect the base branch dynamically.** Use the shared branch lifecycle contract from AGENTS.md: `git symbolic-ref refs/remotes/origin/HEAD`, fall back to `main`, then `master`. Never hardcode the default branch name.
 - If on the default branch or not in a worktree, warn and stop.

--- a/tests/test_convert_worktree_untracked_review_gate.py
+++ b/tests/test_convert_worktree_untracked_review_gate.py
@@ -1,0 +1,68 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL = REPO_ROOT / "skills" / "convert-worktree" / "SKILL.md"
+
+
+class ConvertWorktreeUntrackedReviewGateTest(unittest.TestCase):
+    def setUp(self):
+        self.text = SKILL.read_text()
+        self.lower = self.text.lower()
+
+    def test_skill_inventories_working_tree_before_touching_it(self):
+        self.assertIn("git status --short", self.text)
+
+    def test_skill_does_not_blanket_stage_untracked_into_history(self):
+        # Forbid `git add -A` as an actual command in any fenced code block,
+        # but allow prose to reference it as the failure mode being avoided.
+        for block in re.findall(r"```[a-zA-Z]*\n(.*?)```", self.text, flags=re.DOTALL):
+            for line in block.splitlines():
+                self.assertFalse(
+                    re.match(r"^\s*git add -A\b", line),
+                    f"convert-worktree skill must not run `git add -A` as a command: {line!r}",
+                )
+
+    def test_skill_stages_only_tracked_modifications_for_wip_commit(self):
+        self.assertIn("git add -u", self.text)
+
+    def test_skill_only_commits_when_index_has_content(self):
+        self.assertIn('git diff --cached --name-only', self.text)
+
+    def test_skill_stashes_untracked_files_outside_history(self):
+        self.assertIn("git ls-files --others --exclude-standard", self.text)
+        self.assertRegex(
+            self.text,
+            r"git stash push --include-untracked.*convert-worktree:untracked",
+        )
+
+    def test_skill_pops_untracked_stash_after_main_workspace_checkout(self):
+        match = re.search(r'git checkout "\$BRANCH"', self.text)
+        self.assertIsNotNone(match, "skill must checkout branch in main workspace")
+        tail = self.text[match.end():]
+        self.assertIn("git stash pop", tail)
+        self.assertIn("STASHED_UNTRACKED", tail)
+
+    def test_skill_drops_misleading_gitignore_safety_claim(self):
+        self.assertNotIn(
+            "`.gitignore` handles exclusions so `git add -A` is safe",
+            self.text,
+        )
+
+    def test_skill_rules_forbid_auto_committing_untracked_files(self):
+        self.assertRegex(
+            self.lower,
+            r"never auto-commit untracked files",
+        )
+
+    def test_skill_report_surfaces_preserved_untracked_paths(self):
+        self.assertRegex(
+            self.lower,
+            r"untracked.*popped from stash",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Stops `convert-worktree` from blanket-staging the worktree with `git add -A` before removal. Tracked modifications and explicitly staged content go into the WIP commit; unstaged untracked files are stashed with `--include-untracked` and popped in the main workspace after checkout, so they never enter branch history.
- Updates the rule and report so untracked paths are surfaced for the user to review before any deliberate commit.
- Adds `tests/test_convert_worktree_untracked_review_gate.py` to lock in the new contract via static analysis.

Closes #33

## Test plan
- [x] `python3 -m unittest discover -s tests` (30/30 pass)
- [x] Verified the new tests fail against pre-fix `skills/convert-worktree/SKILL.md` from `main` (9/9 fail), then pass after restoring the fix.
- [ ] Manual: from inside a worktree, drop `.env.local` with a fake secret, modify a tracked file, run `/convert-worktree`. Confirm the WIP commit contains only the tracked-file change (`git show HEAD --stat`) and `.env.local` reappears as untracked in the main workspace.