### PR TITLE
refactor(skills): forbid concrete Claude-only leaks in public skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,27 @@ Never hardcode `main` or `master` in skill commands, guards, diff ranges, or use
 
 Shell state does not persist between separate Bash tool invocations. Each skill must either re-resolve `BASE_BRANCH` at the top of every bash block that consumes it, or substitute the resolved literal branch name into the commands the agent runs (instead of letting `$BASE_BRANCH` expand in a fresh shell where it is unset). Do not assume a variable set in step N is still in scope in step N+1.
 
+## Capability glossary for public skills
+
+Public skills are distributed to Claude Code, Codex, and Gemini. Skill prose may use harness-specific tool names where they read naturally (`Task tool`, `WebSearch`, `Agent tool`); other harnesses generally infer the equivalent. This is a **glossary**, not a required vocabulary, that names recurring capabilities so future skills and adapter docs have a shared lexicon to reach for.
+
+| Capability | What it provides |
+| --- | --- |
+| `project.instructions` | The project's own contributor instructions, found in `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md` depending on harness. |
+| `ticket.read` | Read access to the project's ticket system (GitHub Issues, Jira, GitLab Issues, Azure Boards, Linear, etc.). |
+| `ticket.write` | Create, update, comment on, or close tickets in the project's ticket system. |
+| `subagent.dispatch` | Dispatch one isolated subagent with a fresh context, given a single prompt as its full instructions. |
+| `subagent.dispatch.parallel` | Dispatch multiple isolated subagents in parallel from one orchestrator turn. |
+| `web.research` | Fetch content from the public web (search engines, documentation, package registries, release notes). |
+| `verification.run` | Execute the project's verification commands (tests, linters, formatters, type checks) and return their output. |
+
+Two things *are* enforced in public skill bodies because they are concrete failure modes, not stylistic ones, and because untested abstraction would be a bigger regression risk than the current prose. The validator in `tests/test_capability_vocabulary.py` checks both:
+
+- The literal Claude API parameter shape `subagent_type` and its value `general-purpose` must not appear. They are meaningless on Codex and Gemini, where no such parameter exists.
+- Generated PR or commit output must not brand a single harness (no `Generated with [Claude Code]` trailer in PR body templates).
+
+Frontmatter keys (`model:`, `disable-model-invocation:`) are allowed to stay harness-specific.
+
 ## Commits and releases
 
 - Only `feat:` (minor) and `fix:` (patch) drive a release PR. Other conventional types are silently ignored by release-please for bump purposes. Use `feat(skill):` scopes to classify new skills.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -48,9 +48,9 @@ HIGH_RISK_PATHS=$(
 
 **2. Dispatch the code-reviewer subagent:**
 
-Use the Task tool with `subagent_type: "general-purpose"`, passing the filled reviewer prompt (see "Reviewer prompt template" below) as the prompt. The reviewer sees only that prompt, never your session history.
+Use the Task tool, passing the filled reviewer prompt (see "Reviewer prompt template" below) as the prompt. The reviewer sees only that prompt, never your session history.
 
-Do not substitute a specialized reviewer agent from another plugin (for example, `superpowers:code-reviewer`). Those agents carry their own system prompts that layer over the template, making output nondeterministic, and they make this skill silently depend on another plugin being installed. `general-purpose` takes the template as its full instructions, which is what the template is written for.
+Do not substitute a specialized reviewer agent from another plugin (for example, `superpowers:code-reviewer`). Those agents carry their own system prompts that layer over the template, making output nondeterministic, and they make this skill silently depend on another plugin being installed. The default unspecialized subagent takes the template as its full instructions, which is what the template is written for.
 
 **Placeholders:**
 - `{WHAT_WAS_IMPLEMENTED}`, what you just built
@@ -284,7 +284,7 @@ You: Let me request code review before proceeding.
 BASE_SHA=$(git merge-base HEAD "origin/$BASE_BRANCH")
 HEAD_SHA=$(git rev-parse HEAD)
 
-[Dispatch general-purpose subagent with reviewer prompt]
+[Dispatch unspecialized subagent with reviewer prompt]
   WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
   PLAN_OR_REQUIREMENTS: Task 2 from docs/plans/deployment-plan.md
   BASE_SHA: a7981ec

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -78,8 +78,6 @@ Single command to go from "I'm done" to "PR is open."
          <What was tested locally>
 
          Closes #<number>
-
-         Generated with [Claude Code](https://claude.com/claude-code)
          ```
    - Return PR URL to user
 

--- a/tests/test_capability_vocabulary.py
+++ b/tests/test_capability_vocabulary.py
@@ -1,0 +1,111 @@
+"""Concrete-leak validator for public skills.
+
+Public skills are distributed to multiple harnesses (Claude Code, Codex,
+Gemini). Most prose may legitimately use harness-specific tool names; the
+narrow contract this test enforces covers only the failure modes that are
+concrete and untested abstractions cannot fix:
+
+1. AGENTS.md documents the capability glossary so future skills and adapter
+   docs have a shared lexicon to reach for.
+2. Public skill bodies do not contain the literal Claude API parameter shape
+   `subagent_type` or its value `general-purpose`. Those tokens are
+   meaningless on Codex and Gemini, where no such parameter exists.
+3. Generated PR or commit output does not brand a single harness, since the
+   output is user-visible on every harness that runs the skill.
+
+Stylistic harness-specific nouns (`Task tool`, `Agent tool`, `WebSearch`)
+are *not* enforced. Replacing them with abstract capability names removes
+the noun but degrades execution on the harness that has the tool, with no
+measured benefit on harnesses that don't.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+AGENTS = REPO_ROOT / "AGENTS.md"
+
+
+CAPABILITIES = [
+    "project.instructions",
+    "ticket.read",
+    "ticket.write",
+    "subagent.dispatch",
+    "subagent.dispatch.parallel",
+    "web.research",
+    "verification.run",
+]
+
+
+FORBIDDEN_TOKENS = [
+    "subagent_type",
+    "general-purpose",
+]
+
+
+FORBIDDEN_ATTRIBUTION_LINES = [
+    "Generated with [Claude Code]",
+]
+
+
+def strip_frontmatter(text):
+    match = re.match(r"^---\n.*?\n---\n", text, re.DOTALL)
+    return text[match.end():] if match else text
+
+
+def public_skill_files():
+    return sorted(SKILLS_DIR.glob("*/SKILL.md"))
+
+
+class CapabilityVocabularyTest(unittest.TestCase):
+    def test_agents_md_documents_capability_glossary(self):
+        text = AGENTS.read_text()
+        self.assertIn(
+            "Capability glossary",
+            text,
+            "AGENTS.md must include a 'Capability glossary' section so "
+            "future skills and adapter docs share a lexicon",
+        )
+        for capability in CAPABILITIES:
+            with self.subTest(capability=capability):
+                self.assertIn(
+                    capability,
+                    text,
+                    f"AGENTS.md must name the capability {capability!r}",
+                )
+
+    def test_public_skill_bodies_avoid_claude_api_parameter_shapes(self):
+        for skill_path in public_skill_files():
+            skill_name = skill_path.parent.name
+            body = strip_frontmatter(skill_path.read_text())
+            for token in FORBIDDEN_TOKENS:
+                with self.subTest(skill=skill_name, token=token):
+                    self.assertNotIn(
+                        token,
+                        body,
+                        f"{skill_name}: token {token!r} is a literal Claude "
+                        "API parameter shape that has no meaning on Codex or "
+                        "Gemini. Reword to describe the behavior, not the "
+                        "parameter.",
+                    )
+
+    def test_public_skill_bodies_do_not_brand_generated_output(self):
+        for skill_path in public_skill_files():
+            skill_name = skill_path.parent.name
+            body = strip_frontmatter(skill_path.read_text())
+            for line in FORBIDDEN_ATTRIBUTION_LINES:
+                with self.subTest(skill=skill_name, line=line):
+                    self.assertNotIn(
+                        line,
+                        body,
+                        f"{skill_name}: hardcoded {line!r} in generated PR or "
+                        "commit output brands a cross-harness skill for one "
+                        "harness. Remove or make neutral.",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Public skills are distributed to Claude Code, Codex, and Gemini. Two leaks in the public surface were concrete failure modes rather than stylistic ones, and worth enforcing:

- `skills/code-review/SKILL.md` named the literal Claude API parameter shape `subagent_type: "general-purpose"`. That parameter does not exist on Codex or Gemini, so the directive cannot be followed there. Reworded to "Use the Task tool, ..." and "the default unspecialized subagent ..." which keeps the Claude-Code-natural noun without the meaningless API shape.
- `skills/pr/SKILL.md` hardcoded `Generated with [Claude Code]` in the PR body template. The PR body is user-visible output on every harness that runs the skill. Removed.

`AGENTS.md` gains a "Capability glossary" section that names recurring capabilities (`project.instructions`, `ticket.read`, `ticket.write`, `subagent.dispatch`, `subagent.dispatch.parallel`, `web.research`, `verification.run`) so future skills and adapter docs share a lexicon to reach for. **Skill prose is not required to use these names.** Replacing working concrete tool nouns (`Task tool`, `WebSearch`, `Agent tool`) with abstract capability names removes the noun but degrades execution on the harness that has the tool, with no measured benefit on harnesses that don't.

`tests/test_capability_vocabulary.py` enforces three narrow invariants: the AGENTS.md glossary exists and names the listed capabilities, no public skill body contains `subagent_type` or `general-purpose`, and no public skill body contains the Claude Code PR trailer.

## Scope notes

This is a deliberately scoped-down version of the full vocabulary rollout originally proposed in #35. The broader rewrites (replacing `WebSearch`/`Task tool`/`Agent tool` and bare `CLAUDE.md` references with abstract capability prose) were tried, then reverted, because:

1. The abstraction trades a *concrete-but-wrong-on-2/3-harnesses* noun for an *abstract-but-correct-for-3/3* noun. Net benefit depends on inference reliability we have not measured.
2. Skill prose verbosity roughly doubled at every replacement site, raising future maintenance cost.
3. The validator was textual, not behavioral. It could let new leaks through (e.g., the reviewer caught "Enter plan mode" was missed) and offered no evidence the rewrites actually improve execution.

The narrow contract here keeps the wins that are unambiguous (literal API parameter shapes, visible branding) and leaves stylistic tool-noun choices to skill authors.

## Test plan

- [x] `python -m unittest discover tests` — 33/33 pass
- [x] `ruff check tests/test_capability_vocabulary.py` — clean
- [x] `grep -r 'subagent_type\|general-purpose\|Generated with \[Claude Code\]' skills/*/SKILL.md` — zero hits in skill bodies
- [ ] Manual: open `/pr` and confirm generated PR body no longer carries the Claude Code trailer

Closes #35