### PR TITLE
chore(triage): learn from not-planned rejections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ Every `skills/<name>/` is public API. All three harnesses discover the same `SKI
 
 Never duplicate a skill into a harness-specific subtree. All three harnesses auto-discover `skills/<name>/SKILL.md`. The `model` frontmatter key is honored by Claude Code and ignored by Codex and Gemini.
 
+## Deployment context for this repo
+
+The skills in this repo are personal-machine tooling for an individual operator, not multi-user infrastructure. Threat models that assume shared hosts, shared `$TMPDIR`, untrusted local processes, network-exposed services, or supply-chain attackers reading per-user temp do not apply when triaging this codebase. Cached ticket bodies, project maps, and run state live in the operator's per-user temp (on macOS, `/var/folders/.../T/`, mode 700, owned by the operator) alongside `~/.ssh/`, `~/.aws/`, browser cookies, and keychain data the operating system already keeps private.
+
+When `triage-architecture`, `triage-bugs`, or any other skill audits this repo, ground every security or robustness concern in this context. Hardening proposed with the framing "in case the cache is read by another user", "if `$TMPDIR` is shared", "if a co-tenant on the host", or "to defend against a local attacker" is out of scope and should be downgraded or rejected, not filed. Real concerns in this context look like: secrets actually committed to the repo, dependency CVEs that affect runtime behavior, public-API correctness bugs, data loss in the operator's own workflow, or footguns that turn into real bugs on a single-user machine.
+
+This boundary is load-bearing for the triage skills' rejection-learning loop: when the operator closes a ticket as not-planned with reasoning grounded in this context, the triage skills cache that reasoning into `issues-closed.json` so future runs can recognize the same class of concern under a different title and skip refiling.
+
 ## Mechanical skills
 
 Skills whose lifecycle is almost entirely deterministic git, shell, and `gh` orchestration declare `disable-model-invocation: true` in frontmatter so harnesses skip expensive model reasoning for them. Currently honored by Claude Code, tolerated by Codex and Gemini. Apply to `pr`, `ship`, and `convert-worktree`. Add the key to any future skill whose body is a fixed command sequence rather than judgement-driven work.

--- a/skills/triage-architecture/SKILL.md
+++ b/skills/triage-architecture/SKILL.md
@@ -59,7 +59,9 @@ Using the detected ticket system's CLI tools, MCP tools, or APIs, fetch tickets 
 
 If time-windowed refine returns zero results, tell the user and stop. Do not dispatch sub-agents.
 
-**Closed tickets (titles only):** Fetch recently closed tickets labeled `architecture`, `product`, or `bug` (titles, IDs, and labels only). Merge into a single deduplicated list. Write to `<cache>/issues-closed.json`.
+**Closed tickets (with rejection reasoning):** Fetch recently closed tickets labeled `architecture`, `product`, or `bug`. Include title, ID, labels, and the close-state metadata available in the ticket system. For GitHub Issues, that means `stateReason` (`completed` vs `not_planned`); for Jira, the `resolution` field; for other systems, the analogous "won't do" or "wontfix" marker. For tickets closed as not-planned, wontfix, or equivalent, also fetch the closing comment so the rejection reasoning is preserved with the ticket. Merge into a single deduplicated list. Write to `<cache>/issues-closed.json`.
+
+Sub-agents use this cache for two purposes: (a) avoid duplicating tickets already filed and resolved, and (b) learn from prior not-planned rejections about which classes of concerns this project deems inapplicable, so a refile under a slightly different title still gets caught.
 
 Normalize all fetched data into a consistent JSON shape regardless of the source platform.
 
@@ -164,7 +166,7 @@ Do NOT fetch ticket lists yourself. Tickets are cached on disk.
 
 - `{CACHE_DIR}/issues-open.json`, all open tickets with full detail. **Read-only context** for awareness and cross-references.
 - `{CACHE_DIR}/issues-edit-{CLUSTER_SLUG}.json`, tickets assigned to YOUR cluster. You may ONLY modify tickets in this file.
-- `{CACHE_DIR}/issues-closed.json`, closed tickets with titles and labels only. Check this before filing new tickets to avoid duplicating something already resolved.
+- `{CACHE_DIR}/issues-closed.json`, closed tickets with title, labels, close-state metadata, and the closing comment for tickets closed as not-planned/wontfix. Check this before filing a new ticket. A new ticket is a refile if (a) its title duplicates a closed ticket, or (b) its premise relies on a threat model, assumption, or framing that a not-planned ticket explicitly rejected. Read the rejection comment, do not just dedup by title.
 
 **Edit constraint:** You may ONLY execute write commands (edit, close, create) against tickets in your edit file. For tickets outside your edit file, you have read-only access via `issues-open.json`. If you discover something relevant to a ticket outside your cluster, write it to your cross-cluster notes file at `{CACHE_DIR}/cross-cluster-{CLUSTER_SLUG}.json`. Do NOT add comments to any ticket.
 
@@ -288,7 +290,7 @@ Hard cap: maximum 3 new tickets.
 
 Before creating any ticket, scan existing tickets for overlap:
 1. Read ticket titles and descriptions in issues-open.json. Is this problem already covered?
-2. Check issues-closed.json titles. Was this already filed and resolved?
+2. Check issues-closed.json. Was this already filed? For tickets closed as `completed`, you have a direct title-level duplicate. For tickets closed as `not_planned` (or wontfix in non-GitHub systems), read the closing comment, if your candidate shares the rejected ticket's threat model, assumption, or framing, treat it as a refile and do not file it, even if the title differs.
 3. If already covered and your finding adds context: if the ticket is in your edit file, edit the description directly. If it is outside your edit file, write it to your cross-cluster notes file. Do NOT add comments. Do NOT rewrite existing ticket descriptions, that's refine's job.
 4. If not covered: create a new focused ticket.
 

--- a/skills/triage-bugs/SKILL.md
+++ b/skills/triage-bugs/SKILL.md
@@ -59,7 +59,9 @@ Using the detected ticket system's CLI tools, MCP tools, or APIs, fetch tickets 
 
 If time-windowed refine returns zero results, tell the user and stop. Do not dispatch sub-agents.
 
-**Closed tickets (titles only):** Fetch recently closed tickets labeled `bug`, `architecture`, or `product` (titles, IDs, and labels only). Merge into a single deduplicated list. Write to `<cache>/issues-closed.json`.
+**Closed tickets (with rejection reasoning):** Fetch recently closed tickets labeled `bug`, `architecture`, or `product`. Include title, ID, labels, and the close-state metadata available in the ticket system. For GitHub Issues, that means `stateReason` (`completed` vs `not_planned`); for Jira, the `resolution` field; for other systems, the analogous "won't do" or "wontfix" marker. For tickets closed as not-planned, wontfix, or equivalent, also fetch the closing comment so the rejection reasoning is preserved with the ticket. Merge into a single deduplicated list. Write to `<cache>/issues-closed.json`.
+
+Sub-agents use this cache for two purposes: (a) avoid duplicating tickets already filed and resolved, and (b) learn from prior not-planned rejections about which classes of concerns this project deems inapplicable, so a refile under a slightly different title still gets caught.
 
 Normalize all fetched data into a consistent JSON shape regardless of the source platform.
 
@@ -171,7 +173,7 @@ Do NOT fetch ticket lists yourself. Tickets are cached on disk.
 
 - `{CACHE_DIR}/issues-open.json`, all open tickets with full detail. **Read-only context** for awareness and cross-references.
 - `{CACHE_DIR}/issues-edit-{CLUSTER_SLUG}.json`, tickets assigned to YOUR cluster. You may ONLY modify tickets in this file.
-- `{CACHE_DIR}/issues-closed.json`, closed tickets with titles and labels only. Check this before filing new tickets to avoid duplicating something already resolved.
+- `{CACHE_DIR}/issues-closed.json`, closed tickets with title, labels, close-state metadata, and the closing comment for tickets closed as not-planned/wontfix. Check this before filing a new ticket. A new ticket is a refile if (a) its title duplicates a closed ticket, or (b) its premise relies on a threat model, assumption, or framing that a not-planned ticket explicitly rejected. Read the rejection comment, do not just dedup by title.
 
 **Edit constraint:** You may ONLY execute write commands (edit, close, create) against tickets in your edit file. For tickets outside your edit file, you have read-only access via `issues-open.json`. If you discover something relevant to a ticket outside your cluster, write it to your cross-cluster notes file at `{CACHE_DIR}/cross-cluster-{CLUSTER_SLUG}.json`. Do NOT add comments to any ticket.
 
@@ -325,7 +327,7 @@ Hard cap: maximum 3 new tickets. One excellent report beats five weak ones.
 
 Before creating any ticket, scan existing tickets for overlap:
 1. Read ticket titles and descriptions in issues-open.json. Is this defect already covered?
-2. Check issues-closed.json titles. Was this already filed and resolved?
+2. Check issues-closed.json. Was this already filed? For tickets closed as `completed`, you have a direct title-level duplicate. For tickets closed as `not_planned` (or wontfix in non-GitHub systems), read the closing comment, if your candidate shares the rejected ticket's threat model, assumption, or framing, treat it as a refile and do not file it, even if the title differs.
 3. If already covered and your finding adds evidence: if the ticket is in your edit file, edit the description to add the proof. If it is outside your edit file, write it to your cross-cluster notes file. Do NOT add comments. Do NOT rewrite existing ticket descriptions, that's refine's job.
 4. If not covered: file a new ticket after passing the pre-filing gate.
 

--- a/skills/triage-product/SKILL.md
+++ b/skills/triage-product/SKILL.md
@@ -59,7 +59,9 @@ Using the detected ticket system's CLI tools, MCP tools, or APIs, fetch tickets 
 
 If time-windowed refine returns zero results, tell the user and stop. Do not dispatch sub-agents.
 
-**Closed tickets (titles only):** Fetch recently closed tickets labeled `architecture`, `product`, or `bug` (titles, IDs, and labels only). Merge into a single deduplicated list. Write to `<cache>/issues-closed.json`.
+**Closed tickets (with rejection reasoning):** Fetch recently closed tickets labeled `architecture`, `product`, or `bug`. Include title, ID, labels, and the close-state metadata available in the ticket system. For GitHub Issues, that means `stateReason` (`completed` vs `not_planned`); for Jira, the `resolution` field; for other systems, the analogous "won't do" or "wontfix" marker. For tickets closed as not-planned, wontfix, or equivalent, also fetch the closing comment so the rejection reasoning is preserved with the ticket. Merge into a single deduplicated list. Write to `<cache>/issues-closed.json`.
+
+Sub-agents use this cache for two purposes: (a) avoid duplicating tickets already filed and resolved, and (b) learn from prior not-planned rejections about which classes of concerns this project deems inapplicable, so a refile under a slightly different title still gets caught.
 
 Normalize all fetched data into a consistent JSON shape regardless of the source platform.
 
@@ -164,7 +166,7 @@ Do NOT fetch ticket lists yourself. Tickets are cached on disk.
 
 - `{CACHE_DIR}/issues-open.json`, all open tickets with full detail. **Read-only context** for awareness and cross-references.
 - `{CACHE_DIR}/issues-edit-{CLUSTER_SLUG}.json`, tickets assigned to YOUR cluster. You may ONLY modify tickets in this file.
-- `{CACHE_DIR}/issues-closed.json`, closed tickets with titles and labels only. Check this before filing new tickets to avoid duplicating something already resolved.
+- `{CACHE_DIR}/issues-closed.json`, closed tickets with title, labels, close-state metadata, and the closing comment for tickets closed as not-planned/wontfix. Check this before filing a new ticket. A new ticket is a refile if (a) its title duplicates a closed ticket, or (b) its premise relies on a threat model, assumption, or framing that a not-planned ticket explicitly rejected. Read the rejection comment, do not just dedup by title.
 
 **Edit constraint:** You may ONLY execute write commands (edit, close, create) against tickets in your edit file. For tickets outside your edit file, you have read-only access via `issues-open.json`. If you discover something relevant to a ticket outside your cluster, write it to your cross-cluster notes file at `{CACHE_DIR}/cross-cluster-{CLUSTER_SLUG}.json`. Do NOT add comments to any ticket.
 
@@ -274,7 +276,7 @@ Hard cap: maximum 3 new tickets.
 
 Before creating any ticket, scan existing tickets for overlap:
 1. Read ticket titles and descriptions in issues-open.json. Is this problem already covered?
-2. Check issues-closed.json titles. Was this already filed and resolved?
+2. Check issues-closed.json. Was this already filed? For tickets closed as `completed`, you have a direct title-level duplicate. For tickets closed as `not_planned` (or wontfix in non-GitHub systems), read the closing comment, if your candidate shares the rejected ticket's threat model, assumption, or framing, treat it as a refile and do not file it, even if the title differs.
 3. If already covered and your finding adds context: if the ticket is in your edit file, edit the description directly. If it is outside your edit file, write it to your cross-cluster notes file. Do NOT add comments. Do NOT rewrite existing ticket descriptions, that's refine's job.
 4. If not covered: create a new focused ticket.
 

--- a/tests/test_triage_rejection_learning.py
+++ b/tests/test_triage_rejection_learning.py
@@ -1,0 +1,104 @@
+"""Rejection-learning contract for the triage skills.
+
+When the operator closes a ticket as not-planned (GitHub `stateReason`,
+Jira `resolution`, or the analogous "won't do" marker on other systems),
+the triage skills must cache the rejection reasoning and surface it to
+sub-agents during dedup so a refile under a slightly different title gets
+caught. This test pins the contract surface in two places:
+
+1. AGENTS.md documents the deployment context that grounds rejection
+   decisions for this repo.
+
+2. Each triage skill (`triage-architecture`, `triage-bugs`,
+   `triage-product`) instructs the orchestrator to fetch close-state
+   metadata plus closing comments for not-planned tickets, and instructs
+   sub-agents to use that reasoning during dedup, not just title matches.
+"""
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+AGENTS = REPO_ROOT / "AGENTS.md"
+
+
+TRIAGE_SKILLS = [
+    "triage-architecture",
+    "triage-bugs",
+    "triage-product",
+]
+
+
+AGENTS_REQUIRED_PHRASES = [
+    "deployment context",
+    "personal-machine tooling",
+    "rejection-learning",
+    "not-planned",
+]
+
+
+# Phrases that pin the closed-fetch contract: orchestrator must capture
+# close-state metadata and the closing comment for rejected tickets.
+SKILL_FETCH_PHRASES = [
+    "rejection reasoning",
+    "stateReason",
+    "not-planned",
+    "closing comment",
+]
+
+
+# Phrases that pin the dedup-check contract: sub-agents must read
+# rejection reasoning, not just title-match the closed cache.
+SKILL_DEDUP_PHRASES = [
+    "not_planned",
+    "threat model",
+    "do not just dedup by title",
+]
+
+
+class TriageRejectionLearningTest(unittest.TestCase):
+    def skill_text(self, skill_name):
+        return (SKILLS_DIR / skill_name / "SKILL.md").read_text()
+
+    def test_agents_md_documents_deployment_context(self):
+        text = AGENTS.read_text().lower()
+        for phrase in AGENTS_REQUIRED_PHRASES:
+            with self.subTest(phrase=phrase):
+                self.assertIn(
+                    phrase.lower(),
+                    text,
+                    f"AGENTS.md must include {phrase!r} so triage runs in "
+                    "this repo can ground their threat-model decisions",
+                )
+
+    def test_triage_skills_fetch_close_reason_and_reasoning(self):
+        for skill_name in TRIAGE_SKILLS:
+            text = self.skill_text(skill_name).lower()
+            for phrase in SKILL_FETCH_PHRASES:
+                with self.subTest(skill=skill_name, phrase=phrase):
+                    self.assertIn(
+                        phrase.lower(),
+                        text,
+                        f"{skill_name}: closed-ticket fetch must preserve "
+                        f"{phrase!r} so sub-agents can learn from prior "
+                        "rejections",
+                    )
+
+    def test_triage_dedup_uses_rejection_reasoning_not_just_titles(self):
+        for skill_name in TRIAGE_SKILLS:
+            text = self.skill_text(skill_name).lower()
+            for phrase in SKILL_DEDUP_PHRASES:
+                with self.subTest(skill=skill_name, phrase=phrase):
+                    self.assertIn(
+                        phrase.lower(),
+                        text,
+                        f"{skill_name}: dedup check must include {phrase!r} "
+                        "so a refile under a different title still gets "
+                        "caught when its premise was already rejected",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_triage_rejection_learning.py
+++ b/tests/test_triage_rejection_learning.py
@@ -50,11 +50,18 @@ SKILL_FETCH_PHRASES = [
 
 
 # Phrases that pin the dedup-check contract: sub-agents must read
-# rejection reasoning, not just title-match the closed cache.
+# rejection reasoning, not just title-match the closed cache. Each phrase
+# is load-bearing in a *different* location so a half-revert in any one
+# location is detected:
+# - "direct title-level duplicate" appears only in the Dedup Check step.
+# - "do not just dedup by title" appears only in the Cached Tickets blurb.
+# - "threat model" appears in both, plus AGENTS.md.
+# - "not_planned" appears in the Step 1 fetch and the Dedup Check step.
 SKILL_DEDUP_PHRASES = [
     "not_planned",
     "threat model",
     "do not just dedup by title",
+    "direct title-level duplicate",
 ]
 
 


### PR DESCRIPTION
## Summary

- Add `Deployment context for this repo` to AGENTS.md, naming this codebase's threat-model boundary (single-user personal-machine tool; multi-user/shared-host/local-attacker models out of scope).
- Triage skills (`triage-architecture`, `triage-bugs`, `triage-product`) now fetch close-state metadata (GitHub `stateReason`, Jira `resolution`, etc.) and the closing comment for not-planned tickets, and instruct sub-agents to read the rejection reasoning during dedup. A candidate that shares a rejected ticket's threat model, assumption, or framing is treated as a refile even when its title differs.
- New `tests/test_triage_rejection_learning.py` pins the contract: AGENTS.md must define the deployment context, each triage skill must capture close reason + closing comment, and dedup must use rejection reasoning. Phrases are chosen so a half-revert in any of the three load-bearing locations (Step 1 fetch, Cached Tickets blurb, Dedup Check step) trips the test.

Motivation: the triage skills only saw closed-ticket titles + labels, so a ticket closed as not-planned because its premise didn't fit this project (e.g. issue #31's multi-user-host threat model in a single-user-machine tool) silently became invisible to the next triage run, and a refile under a different title would slip past the title-only dedup. AGENTS.md alone is not enough (sub-agents could still file similarly framed concerns); the closed-cache change alone is not enough (sub-agents need to understand why something was rejected). The two changes are landed together because they only work in combination.

## Test plan

- [x] `for f in tests/test_*.py; do python "$f"; done` — 9 files, 43 tests pass
- [x] `ruff check tests/` — clean
- [x] `ruff format --check tests/test_triage_rejection_learning.py` — clean
- [ ] Run `/agentic-toolkit:triage-architecture refine` against this repo after merge; inspect `<temp>/triage-architecture-<PROJECT_ID>/issues-closed.json` and confirm issue #31 carries `stateReason: not_planned` and the closing comment
- [ ] Confirm a sub-agent proposing a temp-cache hardening ticket under any title gets caught as a refile of #31's rejected premise