### PR TITLE
feat(get-it-right): footprint guard before auto-implementation

### DIFF
--- a/docs/superpowers/specs/2026-04-26-get-it-right-diff-guard-design.md
+++ b/docs/superpowers/specs/2026-04-26-get-it-right-diff-guard-design.md
@@ -1,0 +1,55 @@
+# get-it-right Footprint Guard Design
+
+## Problem
+
+`skills/get-it-right/SKILL.md` re-architects the current branch and auto-implements without committing. Its only safety rails are "tests must pass" and the principle "preserve all existing behavior." For projects with thin test coverage, the skill can silently rewrite far beyond the branch's original footprint, then hand the user a 3 to 6 item testing playbook. An AFK reviewer who only validates the playbook and merges has no signal that the change set ballooned.
+
+## Fix
+
+Add a quantitative checkpoint between Step 4 (Plan the Re-architecture) and Step 5 (Auto-Implement). The skill compares the planned footprint to the branch's existing footprint against the default branch and stops to confirm with the user when the plan strays beyond a documented bound. The guard is a stop-and-report, not a kill-switch. Within bounds, the skill proceeds to auto-implement as before.
+
+## Footprint definitions
+
+- Original footprint: `git diff --name-only "$BASE_BRANCH"...HEAD`. Files the branch already touches against the default branch.
+- Planned footprint: every file the Step 4 plan intends to modify, create, or delete.
+- Net-new files: files in the planned footprint that are not in the original footprint.
+- Net-removed files: files in the original footprint the plan no longer touches at all (rare but possible when consolidation absorbs a file's contents elsewhere).
+
+## Threshold
+
+Stop and ask the user to confirm when any of these is true:
+
+1. Net-new files exceed 50% of the original footprint count.
+2. Original footprint has 1 to 3 files and net-new files exceed 2. The percentage rule alone is too sharp on tiny branches; a 1-file branch tripping at 1 net-new file would be noise.
+3. Any net-new or net-removed file is not justified by a stated retrospective insight from Step 3.
+
+50% is the published threshold. It tolerates ordinary re-architecture moves (extract one helper, split one module) on a typical branch of 4 to 20 files, while catching the failure mode where the plan triples the footprint. The exact number is debatable and the prose flags it as such; the load-bearing requirement is that there is a documented limit and a stop point.
+
+## Step order
+
+```
+1. Identify Scope
+1.5. Untrusted Content Boundary
+2. Deep-Read Current Implementation
+3. Retrospective Analysis
+4. Plan the Re-architecture
+4.5. Footprint Guard            <-- new checkpoint
+5. Auto-Implement
+6. Output Testing Playbook
+```
+
+Step 4.5 prints the original footprint, the planned footprint, the net-new and net-removed lists with their justifying retrospective insight (or "no insight cited" if absent), the count delta, and the percentage. If any threshold trips, the skill stops and asks the user to confirm or revise the plan. If all thresholds hold, it proceeds to Step 5 without prompting.
+
+The workflow digraph at the top of `SKILL.md` gains a `"Plan re-architecture" -> "Footprint guard" -> "Auto-implement (no commit)"` edge.
+
+## Key Principles update
+
+Add: "Stay within the branch's footprint. Re-architecture that adds files outside the branch's existing diff against the default branch needs the user's confirmation before auto-implementing."
+
+## Test
+
+`tests/test_get_it_right_footprint_guard.py` asserts the SKILL.md prose:
+
+- Mentions a footprint comparison before Step 5 / Auto-Implement.
+- Names a stop-and-confirm condition tied to original-branch footprint.
+- Carries the bounded-footprint principle in Key Principles.

--- a/skills/get-it-right/SKILL.md
+++ b/skills/get-it-right/SKILL.md
@@ -15,7 +15,8 @@ digraph get_it_right {
     "Identify scope" -> "Deep-read implementation";
     "Deep-read implementation" -> "Retrospective analysis";
     "Retrospective analysis" -> "Plan re-architecture";
-    "Plan re-architecture" -> "Auto-implement (no commit)";
+    "Plan re-architecture" -> "Footprint guard";
+    "Footprint guard" -> "Auto-implement (no commit)";
     "Auto-implement (no commit)" -> "Format + lint + test";
     "Format + lint + test" -> "Output testing playbook";
 }
@@ -72,6 +73,48 @@ Enter plan mode. The plan must:
 - Target reduced file count, reduced indirection, consolidated logic
 - Preserve all existing behavior (re-architecture, not behavior change)
 
+### 4.5. Footprint Guard
+
+Before auto-implementing, compare the planned footprint to the branch's existing footprint against the default branch. The guard is a stop-and-report checkpoint, not a kill-switch: within bounds the skill proceeds to Step 5 without prompting; outside bounds it stops and asks the user to confirm or revise the plan.
+
+Re-resolve the default branch (shell state does not persist across bash blocks):
+
+```bash
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+if [ -z "$BASE_BRANCH" ]; then
+  git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+fi
+git diff --name-only "$BASE_BRANCH"...HEAD
+```
+
+Define the footprints:
+
+- Original footprint: the file list from `git diff --name-only "$BASE_BRANCH"...HEAD` above. Files the branch already touches.
+- Planned footprint: every file the Step 4 plan intends to modify, create, or delete.
+- Net-new files: planned footprint minus original footprint.
+- Net-removed files: original footprint minus planned footprint (a file the branch already touches that the plan no longer touches at all).
+
+Stop and ask the user to confirm when any of these is true:
+
+1. Net-new files exceed 50% of the original footprint count.
+2. Original footprint has 1 to 3 files and net-new files exceed 2. The percentage rule is too sharp on tiny branches; this minimum allowance keeps the guard from tripping on a one-file branch that legitimately splits into two.
+3. Any net-new or net-removed file is not justified by a stated retrospective insight from Step 3.
+
+50% is the published threshold. It tolerates ordinary re-architecture moves, extracting one helper, splitting one module, on a typical branch of 4 to 20 files, while catching the failure mode where the plan triples the footprint. The exact number is debatable; the load-bearing requirement is that there is a documented limit and a stop point.
+
+When the guard trips, print:
+
+- Original footprint count and file list.
+- Planned footprint count and file list.
+- Net-new files with the retrospective insight that justifies each, or "no insight cited" if absent.
+- Net-removed files with the same justification annotation.
+- Total count delta and the net-new percentage.
+- Which threshold tripped.
+
+Then ask the user to confirm proceeding or to revise the plan. Do not auto-implement until the user responds.
+
+When the guard holds, print a one-line summary (original count, planned count, net-new count, net-new percent) and proceed to Step 5.
+
 ### 5. Auto-Implement
 
 Execute the plan without user interaction:
@@ -94,5 +137,6 @@ After implementation, output a brief playbook the user follows in the running ap
 - **Fewer files > more files.** Consolidate unless separation of concerns demands otherwise.
 - **Fewer abstractions > more abstractions.** Every indirection layer must earn its keep.
 - **Tests are the constraint.** All existing behavior must be preserved. Tests must pass.
+- **Stay within the branch's footprint.** Re-architecture that adds files outside the branch's existing diff against the default branch needs the user's confirmation before auto-implementing. The footprint guard in Step 4.5 documents the threshold and the stop point.
 - **Don't commit.** The user reviews everything before any git operations.
-- **Don't ask.** Auto-implement unaided. The testing playbook is how the user validates.
+- **Don't ask.** Auto-implement unaided when the footprint guard holds. The testing playbook is how the user validates.

--- a/tests/test_get_it_right_footprint_guard.py
+++ b/tests/test_get_it_right_footprint_guard.py
@@ -1,0 +1,114 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills" / "get-it-right" / "SKILL.md"
+
+
+class GetItRightFootprintGuardTest(unittest.TestCase):
+    def setUp(self):
+        self.text = SKILL_PATH.read_text()
+        self.lower = self.text.lower()
+
+    def _index_of(self, needle, *, start=0):
+        idx = self.lower.find(needle.lower(), start)
+        self.assertNotEqual(
+            idx,
+            -1,
+            f"expected to find {needle!r} in skills/get-it-right/SKILL.md",
+        )
+        return idx
+
+    def test_footprint_guard_appears_before_auto_implement_step(self):
+        guard_idx = self._index_of("footprint guard")
+        auto_impl_idx = self._index_of("### 5. auto-implement")
+        self.assertLess(
+            guard_idx,
+            auto_impl_idx,
+            "footprint guard prose must appear before Step 5 (Auto-Implement)",
+        )
+
+    def test_guard_compares_planned_footprint_to_original_branch_diff(self):
+        # The guard must define what it compares: a planned footprint vs the
+        # branch's existing diff against the default branch.
+        for phrase in [
+            "planned footprint",
+            "original footprint",
+            'git diff --name-only "$base_branch"...head',
+        ]:
+            with self.subTest(phrase=phrase):
+                self.assertIn(
+                    phrase,
+                    self.lower,
+                    f"footprint guard must reference {phrase!r}",
+                )
+
+    def test_guard_names_a_stop_and_confirm_condition(self):
+        # The guard must name a stop point tied to the original-branch footprint,
+        # not just describe the comparison abstractly.
+        guard_section = self._extract_guard_section()
+        guard_lower = guard_section.lower()
+        self.assertTrue(
+            "stop" in guard_lower and "confirm" in guard_lower,
+            "guard prose must name a stop-and-confirm condition",
+        )
+        self.assertIn(
+            "net-new",
+            guard_lower,
+            "guard must describe net-new files vs the original footprint",
+        )
+        # A documented threshold must be present, expressed as prose.
+        self.assertTrue(
+            re.search(r"\b50\s*%|\bfifty percent\b", guard_lower),
+            "guard must publish a concrete threshold in prose",
+        )
+
+    def test_guard_appears_in_key_principles(self):
+        principles_idx = self._index_of("## key principles")
+        principles_section = self.lower[principles_idx:]
+        self.assertIn(
+            "stay within the branch's footprint",
+            principles_section,
+            "Key Principles list must include the bounded-footprint principle",
+        )
+        self.assertIn(
+            "footprint guard",
+            principles_section,
+            "Key Principles must point at the footprint guard step",
+        )
+
+    def test_workflow_digraph_includes_footprint_guard_node(self):
+        # The workflow diagram at the top must show the new checkpoint between
+        # planning and auto-implementation.
+        digraph_match = re.search(
+            r"```dot.*?```",
+            self.text,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(
+            digraph_match,
+            "workflow digraph block must exist in SKILL.md",
+        )
+        digraph = digraph_match.group(0).lower()
+        self.assertIn("footprint guard", digraph)
+        self.assertIn(
+            '"plan re-architecture" -> "footprint guard"',
+            digraph,
+            "digraph must wire planning into the footprint guard",
+        )
+        self.assertIn(
+            '"footprint guard" -> "auto-implement (no commit)"',
+            digraph,
+            "digraph must wire the footprint guard into auto-implementation",
+        )
+
+    def _extract_guard_section(self):
+        start = self._index_of("### 4.5. footprint guard")
+        end = self._index_of("### 5. auto-implement", start=start)
+        return self.text[start:end]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a Step 4.5 footprint guard to `skills/get-it-right/SKILL.md` so the auto-implementation step cannot silently rewrite far beyond the original branch's footprint without surfacing the divergence to the user. Design doc at `docs/superpowers/specs/2026-04-26-get-it-right-diff-guard-design.md`.

## Threshold
Stop and confirm when net-new files exceed 50% of the original footprint, OR when the original footprint has 1 to 3 files and net-new files exceed 2, OR when any added/removed file is not justified by a Step 3 retrospective insight. The percentage rule fits ordinary moves on a 4 to 20 file branch; the absolute floor keeps it from being too sharp on tiny branches.

## Tests
\`python3 -m unittest discover tests\` reports 46 passing (5 new in `tests/test_get_it_right_footprint_guard.py`).