### PR TITLE
fix(ship): screen high-risk paths before push

### DIFF
--- a/docs/superpowers/specs/2026-04-26-ship-secret-screen-design.md
+++ b/docs/superpowers/specs/2026-04-26-ship-secret-screen-design.md
@@ -1,0 +1,31 @@
+# ship Secret-Path Screen Design
+
+## Gap
+
+`skills/ship/SKILL.md` auto-commits, pushes, opens a PR, merges, syncs the default branch, and deletes the feature branch in one shot. Its only safety prose for accidental secret publication is `"If any files or changes look suspect, prompt the user."` That is judgement-driven, not mechanical. `skills/pr/SKILL.md`, whose blast radius is strictly smaller (push only, no merge, no branch delete), already runs an explicit pattern screen against the publication inventory before push. Ship must do at least the same.
+
+## Chosen pattern
+
+Mirror pr character-for-character so the two skills can be deduplicated later. The patterns are:
+
+```
+.env, .env.*, *.pem, *.key, id_rsa*, *.p12, *.pfx, *credential*, *secret*, *.sqlite*
+```
+
+The screen runs against the publication inventory (`git diff --name-status "$BASE_BRANCH"...HEAD`), not the working-tree status. Working-tree-only paths cannot leak to the remote. Committed paths can.
+
+## Where the gate inserts
+
+Ship's current numbered flow places **Push** at step 3, immediately after **Commit** at step 2. The screen must run after the commit (so the publication inventory is final) and before the push (so secrets never reach the remote at all).
+
+The new ordering inserts a pre-push gate as step 3. The previous push step shifts to step 4, and every subsequent step shifts by one. The gate body reuses pr's exact wording for the high-risk pattern list and the resolution paths (remove, gitignore, or explicit user confirmation). It also re-resolves `BASE_BRANCH` at the top of its bash block per AGENTS.md, since shell state does not persist across Bash tool invocations.
+
+## Test plan
+
+Add `tests/test_ship_publish_state_gate.py` modeled on `tests/test_pr_publish_state_gate.py`. The test asserts the ship SKILL.md:
+
+- inventories committed paths with `git diff --name-status "$BASE_BRANCH"...HEAD` before push
+- mentions `high-risk` in the gate prose
+- contains the substrings `.env`, `.pem`, and `credential` (the same anchors the pr test uses)
+
+`python3 -m unittest discover tests` must pass with the existing pr gate test plus the new ship gate test.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -21,13 +21,24 @@ Complete the current branch by committing, pushing, merging, and cleaning up.
 
 1. **Review uncommitted changes**: Run `git status` and `git diff` to see what's uncommitted. If any files or changes look suspect, prompt the user and wait for confirmation before committing.
 2. **Commit**: Stage and commit the confirmed changes with a descriptive message based on the diff.
-3. **Push**: Push the current branch to origin with `-u` flag if not already pushed.
-4. **Create PR** (if none exists): Create a PR using `gh pr create`. Use commit messages to generate the title and body. For forked repos, use `--repo` targeting the user's fork (origin), never upstream.
-5. **Resolve merge strategy**: Read cached repository policy from `$(git rev-parse --git-dir)/agents/repo-policy.json` if present and fresh. If missing, stale, invalid, or for a different repository, refresh it with `gh repo view --json nameWithOwner,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,deleteBranchOnMerge` and write the result back to the cache.
-6. **Merge PR**: Choose the first allowed strategy in this order: `--merge` when `mergeCommitAllowed` is true, else `--squash` when `squashMergeAllowed` is true, else `--rebase` when `rebaseMergeAllowed` is true. Merge with `gh pr merge <strategy>`. For forked repos, use `--repo` targeting the fork. If no strategy is allowed, stop and report the repository merge policy.
-7. **Sync default branch**: `git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"`
-8. **Clean up**: Delete the merged branch locally (`git branch -D`). Only delete the remote branch (`git push origin --delete`) if it still exists. Some repos auto-delete branches on merge.
-9. **Report**: Confirm done with the merged PR URL.
+3. **Pre-push gate** (build the publication inventory before any push):
+
+   ```bash
+   BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+   if [ -z "$BASE_BRANCH" ]; then
+     git rev-parse --verify main >/dev/null 2>&1 && BASE_BRANCH=main || BASE_BRANCH=master
+   fi
+   ```
+
+   - Inventory the publication content: `git diff --name-status "$BASE_BRANCH"...HEAD` lists every committed path the push will publish. Read this list.
+   - Screen the publication inventory for high-risk patterns. Stop and report if any path matches `.env`, `.env.*`, `*.pem`, `*.key`, `id_rsa*`, `*.p12`, `*.pfx`, `*credential*`, `*secret*`, or `*.sqlite*`. The user must remove the path, add it to `.gitignore`, or explicitly confirm before push continues.
+4. **Push**: Push the current branch to origin with `-u` flag if not already pushed.
+5. **Create PR** (if none exists): Create a PR using `gh pr create`. Use commit messages to generate the title and body. For forked repos, use `--repo` targeting the user's fork (origin), never upstream.
+6. **Resolve merge strategy**: Read cached repository policy from `$(git rev-parse --git-dir)/agents/repo-policy.json` if present and fresh. If missing, stale, invalid, or for a different repository, refresh it with `gh repo view --json nameWithOwner,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,deleteBranchOnMerge` and write the result back to the cache.
+7. **Merge PR**: Choose the first allowed strategy in this order: `--merge` when `mergeCommitAllowed` is true, else `--squash` when `squashMergeAllowed` is true, else `--rebase` when `rebaseMergeAllowed` is true. Merge with `gh pr merge <strategy>`. For forked repos, use `--repo` targeting the fork. If no strategy is allowed, stop and report the repository merge policy.
+8. **Sync default branch**: `git checkout "$BASE_BRANCH" && git pull origin "$BASE_BRANCH"`
+9. **Clean up**: Delete the merged branch locally (`git branch -D`). Only delete the remote branch (`git push origin --delete`) if it still exists. Some repos auto-delete branches on merge.
+10. **Report**: Confirm done with the merged PR URL.
 
 ## Repository Policy Cache
 

--- a/tests/test_ship_publish_state_gate.py
+++ b/tests/test_ship_publish_state_gate.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIP_SKILL = REPO_ROOT / "skills" / "ship" / "SKILL.md"
+
+
+class ShipPublishStateGateTest(unittest.TestCase):
+    def setUp(self):
+        self.text = SHIP_SKILL.read_text()
+        self.lower = self.text.lower()
+
+    def test_ship_skill_inventories_committed_paths_before_push(self):
+        self.assertIn('git diff --name-status "$BASE_BRANCH"...HEAD', self.text)
+
+    def test_ship_skill_screens_high_risk_paths_before_push(self):
+        self.assertIn("high-risk", self.lower)
+        for pattern in [".env", ".pem", "credential"]:
+            with self.subTest(pattern=pattern):
+                self.assertIn(pattern, self.lower)
+
+    def test_ship_skill_pre_push_gate_precedes_push_step(self):
+        gate_index = self.lower.find("high-risk")
+        push_index = self.text.find("git push")
+        self.assertNotEqual(gate_index, -1, "high-risk gate prose missing")
+        self.assertNotEqual(push_index, -1, "git push command missing")
+        self.assertLess(
+            gate_index,
+            push_index,
+            "high-risk screen must appear before any push command",
+        )
+
+    def test_ship_skill_resolves_base_branch_in_gate_block(self):
+        self.assertIn(
+            'BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD',
+            self.text,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the same explicit high-risk-path screen to `skills/ship/SKILL.md` that `skills/pr/SKILL.md` already runs before pushing. Today, `ship` (which auto-commits + pushes + merges + deletes the branch) only had the prose `If any files or changes look suspect, prompt the user.`; `pr` had a concrete grep gate validated by `tests/test_pr_publish_state_gate.py`. Same write-to-remote risk profile, weaker gate on the heavier action.

The new gate runs before push, against the publication inventory in `\$BASE_BRANCH..HEAD`, mirroring `pr`'s exact pattern list character-for-character so the two skills can be deduplicated later. On a match `ship` stops and requires the user to remove the path, add it to `.gitignore`, or explicitly confirm.

Design doc: `docs/superpowers/specs/2026-04-26-ship-secret-screen-design.md`.

## Tests
\`python3 -m unittest discover tests\` reports 47 passing (1 new in `tests/test_ship_publish_state_gate.py`).