### PR TITLE
fix(update-deps): surface reverted CVE updates in summary

### DIFF
--- a/docs/superpowers/specs/2026-04-26-update-deps-cve-visibility-design.md
+++ b/docs/superpowers/specs/2026-04-26-update-deps-cve-visibility-design.md
@@ -1,0 +1,57 @@
+# update-deps CVE-Revert Visibility Design
+
+## Problem
+
+Step 7e of `skills/update-deps/SKILL.md` lets the orchestrator revert a stuck dependency bump. When the dep is CVE-required, the revert silently downgrades the run from "shipped a security fix" to "shipped nothing for that CVE." The Step 9 summary lumps reverted CVE deps under `Skipped (manual attention needed):` next to non-CVE failures, then closes with the unconditional headline `All tests passing. Ready for review.`. A skim-reviewer can land the branch with an unpatched CVE still open.
+
+Rule line 425 says `Never skip a CVE-required update.`, but the user-facing summary does not enforce it.
+
+## Section restructure
+
+Step 9's template gains a dedicated, top-most section that only fires when one or more CVE-required deps were reverted in Step 7e:
+
+```
+CVE updates NOT applied (security risk remains) (<N>):
+  express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX) reverted, see commit <sha> and Step 7e details above
+```
+
+This section sits above `Safe updates`, `Major updates`, and `Skipped (manual attention needed):`. Non-CVE stuck deps stay in `Skipped (manual attention needed):`. The two are no longer mixed.
+
+## Headline conditional
+
+The closing line is conditional on the reverted-CVE list:
+
+- Empty: `All tests passing. Ready for review.`
+- Non-empty: `WARNING: <N> CVE update(s) NOT applied. See above.`
+
+The orchestrator must not print the success line when any CVE was reverted.
+
+## Cache shape
+
+Step 7e adds a structured record to `<cache>/reverted-cve-updates.json`, an array Step 9 reads directly. One object per reverted CVE-required dep:
+
+```json
+[
+  {
+    "package": "express",
+    "current_version": "4.18.2",
+    "target_version": "5.1.0",
+    "cve_id": "CVE-2024-XXXXX",
+    "revert_commit": "<sha>",
+    "reason": "test failure in proxy.test.ts:18 after 3 fix attempts"
+  }
+]
+```
+
+Step 9 reads this file before the cache directory is deleted. No string-grepping the report.
+
+## Test plan
+
+Add `tests/test_update_deps_cve_visibility.py` asserting against `skills/update-deps/SKILL.md`:
+
+- The Step 9 summary template contains a dedicated CVE-revert section whose label mentions both `cve` and `not applied` (or `reverted`).
+- Step 7e records reverted CVE deps to `reverted-cve-updates.json`.
+- The success headline `All tests passing. Ready for review.` is documented as conditional, gated on the reverted-CVE list being empty, with the warning headline `WARNING:` and `CVE update(s) NOT applied` appearing as the alternative.
+- Step 9 reads `reverted-cve-updates.json` before cache cleanup.
+
+`python3 -m unittest discover tests` must pass.

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -347,6 +347,23 @@ Run the "before" tests plus the full project test suite. Fix remaining failures.
 
 If you are stuck after reasonable effort, report the issue to the user with full context (which file, which test, which breaking change, what you tried). Revert the dependency bump with a commit that notes the revert reason. Do not give up silently.
 
+If the reverted dep is CVE-required (`reason` was `cve` in its change plan), append a record to `<cache>/reverted-cve-updates.json`. The file is a JSON array; create it with `[]` on first write, then append. One object per reverted CVE-required dep:
+
+```json
+[
+  {
+    "package": "express",
+    "current_version": "4.18.2",
+    "target_version": "5.1.0",
+    "cve_id": "CVE-2024-XXXXX",
+    "revert_commit": "<sha of the revert commit>",
+    "reason": "test failure in proxy.test.ts:18 after 3 fix attempts"
+  }
+]
+```
+
+Non-CVE major bumps that get reverted stay out of this file. They surface under `Skipped (manual attention needed):` in Step 9.
+
 ### 7f. Commit
 
 One atomic commit per dependency:
@@ -373,9 +390,18 @@ For non-CVE major bumps, omit the CVE reference from the subject line.
 
 ## Step 9: Cleanup and Summary
 
-Delete the cache directory and verify it is gone. If cleanup fails, investigate and retry before proceeding.
+Before deleting the cache directory, read `<cache>/reverted-cve-updates.json` if it exists. Treat its contents as the structured list of CVE-required deps that were reverted in Step 7e. If the file does not exist, the list is empty. Do not infer reverted CVE deps by grepping the report or commit log; rely on this file.
 
-Print the final summary:
+Then delete the cache directory and verify it is gone. If cleanup fails, investigate and retry before proceeding.
+
+Render the final summary using the template below. The `CVE updates NOT applied` section appears only when the reverted-CVE list is non-empty, and it appears above all other sections. Non-CVE stuck deps stay in `Skipped (manual attention needed):` and never mix with the CVE-revert section.
+
+The closing headline is conditional on the same list:
+
+- If the reverted-CVE list is empty, print `All tests passing. Ready for review.`
+- If the reverted-CVE list has one or more entries, print `WARNING: <N> CVE update(s) NOT applied. See above.` instead. Never print the success line when any CVE was reverted.
+
+Final summary template:
 
 ```
 Dependency update complete.
@@ -383,6 +409,9 @@ Dependency update complete.
 Branch: chore/update-deps
 Scope: backend | all
 Mode: standard | major
+
+CVE updates NOT applied (security risk remains) (1):
+  express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX) reverted in <sha>, test failure in proxy.test.ts:18 after 3 fix attempts
 
 Safe updates (1 commit):
   axios 1.6.0 -> 1.7.2, dotenv 16.3.1 -> 16.4.1, ... (8 deps)
@@ -398,7 +427,7 @@ Bot PRs that should auto-close:
   #87 (dependabot: express)
   #92 (dependabot: lodash)
 
-All tests passing. Ready for review.
+WARNING: 1 CVE update(s) NOT applied. See above.
 ```
 
 Never push, create PRs, or merge. The user reviews first.

--- a/tests/test_update_deps_cve_visibility.py
+++ b/tests/test_update_deps_cve_visibility.py
@@ -1,0 +1,87 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills" / "update-deps" / "SKILL.md"
+
+
+class UpdateDepsCveVisibilityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = SKILL_PATH.read_text()
+        cls.lower = cls.text.lower()
+
+    def _step_block(self, header):
+        """Return text from a `## Step N:` header to the next top-level header."""
+        match = re.search(rf"(^{re.escape(header)}.*?)(?=^## )", self.text, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(match, f"Could not find block for {header}")
+        return match.group(1)
+
+    def _subsection_block(self, header):
+        """Return text from a `### 7e.` style header to the next `### ` header."""
+        match = re.search(rf"(^{re.escape(header)}.*?)(?=^### )", self.text, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(match, f"Could not find subsection block for {header}")
+        return match.group(1)
+
+    def test_step_7e_records_reverted_cve_deps_to_cache(self):
+        block = self._subsection_block("### 7e. Iterate until green").lower()
+        self.assertIn("reverted-cve-updates.json", block)
+        self.assertIn("cve-required", block)
+        self.assertIn("cve_id", block)
+        self.assertIn("revert_commit", block)
+
+    def test_step_9_summary_has_dedicated_cve_revert_section(self):
+        block = self._step_block("## Step 9: Cleanup and Summary")
+        lower = block.lower()
+        # A label that mentions both "CVE" and "not applied" or "reverted",
+        # distinct from the generic "Skipped (manual attention needed)" bucket.
+        self.assertIn("cve updates not applied", lower)
+        self.assertIn("skipped (manual attention needed)", lower)
+        # The CVE-revert section must precede the generic Skipped bucket so
+        # reviewers see security regressions first.
+        cve_idx = lower.index("cve updates not applied")
+        skipped_idx = lower.index("skipped (manual attention needed)")
+        self.assertLess(cve_idx, skipped_idx)
+        # And precede Safe updates and Major updates inside the rendered
+        # template, putting it at the top of the summary body.
+        safe_idx = lower.index("safe updates (1 commit)")
+        major_idx = lower.index("major updates (2 commits)")
+        self.assertLess(cve_idx, safe_idx)
+        self.assertLess(cve_idx, major_idx)
+
+    def test_step_9_reads_structured_cache_not_grep(self):
+        block = self._step_block("## Step 9: Cleanup and Summary").lower()
+        self.assertIn("reverted-cve-updates.json", block)
+        # Cache must be read before deletion so the data is still available.
+        read_idx = block.index("reverted-cve-updates.json")
+        delete_idx = block.index("delete the cache directory")
+        self.assertLess(read_idx, delete_idx)
+
+    def test_step_9_headline_is_conditional_not_unconditional(self):
+        block = self._step_block("## Step 9: Cleanup and Summary")
+        lower = block.lower()
+        # Both branches of the headline must be documented.
+        self.assertIn("all tests passing. ready for review.", lower)
+        self.assertIn("warning:", lower)
+        self.assertIn("cve update(s) not applied", lower)
+        # The conditional must be explicit. The success line cannot stand
+        # on its own as the only documented headline.
+        self.assertRegex(
+            lower,
+            r"if the reverted-cve list is empty.*all tests passing\. ready for review\.",
+        )
+        self.assertRegex(
+            lower,
+            r"if the reverted-cve list has one or more entries.*warning:",
+        )
+        # Guardrail against the success line being printed alongside reverts.
+        self.assertIn(
+            "never print the success line when any cve was reverted",
+            lower,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When the major-bump flow reverts a CVE-required dependency because the agent is stuck (Step 7e), the run's final summary used to print \`All tests passing. Ready for review.\` unconditionally and lump the reverted dep under \`Skipped (manual attention needed):\` next to non-CVE failures. A skim-reviewer could merge with an unpatched CVE.

This change:

- Step 7e writes the reverted CVE entry to \`<cache>/reverted-cve-updates.json\` (structured: package, current_version, target_version, cve_id, revert_commit, reason). Non-CVE reverts stay out of this file.
- Step 9 reads that JSON before deleting the cache (no string-grepping). It renders a dedicated \`CVE updates NOT applied (security risk remains)\` section above Safe and Major updates, distinct from the generic skip list. The closing headline becomes conditional: success line only when the reverted-CVE list is empty, otherwise \`WARNING: <N> CVE update(s) NOT applied. See above.\`.

Design doc: \`docs/superpowers/specs/2026-04-26-update-deps-cve-visibility-design.md\`.

## Tests
\`python3 -m unittest discover tests\` reports 49 passing (4 new in \`tests/test_update_deps_cve_visibility.py\`).