### PR TITLE
chore(skills): use conventional commit format in workflow skill templates

### DIFF
--- a/docs/superpowers/specs/2026-04-26-conventional-commit-consistency-design.md
+++ b/docs/superpowers/specs/2026-04-26-conventional-commit-consistency-design.md
@@ -1,0 +1,42 @@
+# Conventional Commit Consistency Across Workflow Skills
+
+## Gap
+
+The repo's release pipeline uses release-please, which only bumps versions on Conventional Commits prefixed `feat:` (minor) or `fix:` (patch). Other types are silently ignored for bump purposes (`AGENTS.md`, "Commits and releases"). Several workflow skills today produce or instruct subjects that are not Conventional Commits at all, so any commits an AFK agent emits through `pr`, `ship`, `next-ticket`, `update-deps`, or `convert-worktree` may slip past release-please without a release. The user reviewing the resulting PR has no easy signal that the bump intent was lost.
+
+The non-conformant surfaces are:
+
+- Hardcoded subject templates: `Auto-format and lint fixes`, `Update minor/patch dependencies`, `wip: tracked changes from worktree conversion`, and the `Update express ...` example in `update-deps`.
+- Prose in `pr`, `ship`, and `next-ticket` that tells the agent to write "a descriptive message derived from the diff" without naming Conventional Commits as the format.
+
+## Type-Selection Rule
+
+For prose-derived commits the agent must classify the work and pick from the Conventional Commits type set: `feat` for new functionality, `fix` for bugfixes, `refactor` for restructuring without behavior change, `docs` for documentation-only, `style` for whitespace and formatting, `test` for tests, `perf` for performance, `build` for build-system changes, `ci` for CI configuration, `revert` for reverts, `chore` for everything else.
+
+For `next-ticket` the branch category resolved at Step 5 (`fix/`, `feat/`, `refactor/`, `docs/`, `chore/`) is the natural source of the commit type, so the Step 9 commit subject reuses that mapping directly.
+
+For the hardcoded templates the type is fixed at template-write time:
+
+- Auto-format and lint commits become `style: auto-format and lint fixes`. Conventional Commits reserves `style:` for whitespace and formatting changes that do not affect meaning, which is exactly this case.
+- The batched safe-dep update commit becomes `chore(deps): update minor/patch dependencies`. Routine non-CVE bumps are not user-visible behavior changes.
+- The worktree-conversion preservation commit becomes `chore(worktree): preserve tracked changes during conversion`. The original `wip:` prefix is not a Conventional Commits type; the work captured here is mechanical state preservation, not in-progress feature work.
+- The per-dep major-bump example becomes `fix(deps): update express 4.18.2 to 5.1.0 (CVE-2024-XXXXX)` for the CVE example. Routine non-CVE major bumps in the same flow use `chore(deps):`. CVE patches are functional fixes, hence `fix:`. The same pattern applies generally: CVE-driven dep bumps are `fix(deps):`, routine ones are `chore(deps):`.
+
+## Validator Strategy (`tests/test_conventional_commit_templates.py`)
+
+The validator scans every `skills/*/SKILL.md`, walks fenced code blocks, and inspects only blocks whose first non-blank line looks like a commit subject (a single short line not matching shell, code, or JSON syntax). It also picks up backticks-wrapped phrases that read as a commit subject in prose (e.g., `commit with message "Auto-format and lint fixes"`).
+
+Acceptable prefixes are `feat`, `fix`, `chore`, `refactor`, `docs`, `style`, `test`, `perf`, `build`, `ci`, `revert`. Optional `(scope)` and optional `!` for breaking changes are allowed. Regex: `^(feat|fix|chore|refactor|docs|style|test|perf|build|ci|revert)(\([^)]+\))?!?:\s`.
+
+To avoid false positives on prose paragraphs that happen to live in fenced blocks (e.g., shell snippets, JSON examples), the validator targets two narrow shapes:
+
+1. Fenced blocks whose body is a single short line ending in no terminal punctuation, or whose first line matches a Conventional Commits-shaped subject (i.e., looks like a commit subject template). These are the explicit subject templates such as `Auto-format and lint fixes`.
+2. Prose mentions of literal commit messages quoted in backticks or double-quotes, where the surrounding sentence cues that this string is a commit subject (presence of "commit ... message" or "commit with message" within a small window).
+
+Anything that matches either shape and starts with a non-Conventional prefix fails.
+
+A self-test fixture exercises the regex directly so the validator is verified independently of the live skill content.
+
+## Deviations from Recommended Replacements
+
+None for the hardcoded templates; recommended replacements are adopted as written. For the prose updates (`pr` step 2, `ship` step 2, `next-ticket` step 9), the instruction adds an explicit "Conventional Commits" requirement plus the type-selection rule. `next-ticket` step 9 ties the type to the Step 5 branch category so the agent does not have to redecide.

--- a/skills/convert-worktree/SKILL.md
+++ b/skills/convert-worktree/SKILL.md
@@ -61,7 +61,7 @@ if [ -n "$(git status --porcelain)" ]; then
   # Commit if there's anything in the index. Untracked-and-unstaged files
   # are deliberately not in scope here.
   if [ -n "$(git diff --cached --name-only)" ]; then
-    git commit -m "wip: tracked changes from worktree conversion"
+    git commit -m "chore(worktree): preserve tracked changes during conversion"
   fi
 
   # Stash any remaining untracked files. The stash ref is repo-level, so it

--- a/skills/next-ticket/SKILL.md
+++ b/skills/next-ticket/SKILL.md
@@ -214,7 +214,7 @@ Run the project's formatter (e.g., `make nice`, `npm run format`, `cargo fmt`, `
 
 ## Step 9: Commit
 
-Stage and commit all changes with a descriptive message referencing the ticket. Use whatever closing syntax the platform recognizes for auto-closing tickets from commits (e.g., `Closes #42` for GitHub, `Resolves PROJ-42` for Jira).
+Stage and commit all changes with a Conventional Commits subject referencing the ticket. Reuse the branch category resolved in Step 5 as the commit type: `fix/` becomes `fix:`, `feat/` becomes `feat:`, `refactor/` becomes `refactor:`, `docs/` becomes `docs:`, `chore/` becomes `chore:`. Only `feat:` and `fix:` drive a release-please bump, so the Step 5 category must reflect the actual work category, not a default. Use whatever closing syntax the platform recognizes for auto-closing tickets from commits (e.g., `Closes #42` for GitHub, `Resolves PROJ-42` for Jira).
 
 Do NOT push. Do NOT create a PR. Wait for the user.
 

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -25,7 +25,7 @@ Single command to go from "I'm done" to "PR is open."
 2. **Inventory working tree and commit implementation work**:
    - Capture the working-tree state with `git status --porcelain` and the untracked path list with `git ls-files --others --exclude-standard`
    - Classify every reported path as staged, unstaged, or untracked. Run `git diff --cached` for staged content and `git diff` for unstaged content. Read each untracked file before staging it.
-   - If any paths are present, this is the implementation submission. Stage the intended paths and commit them with a descriptive message derived from the diff. Do not use a `wip:` placeholder. Do not run `git add -A` blindly; stage by explicit path so untracked files are added intentionally.
+   - If any paths are present, this is the implementation submission. Stage the intended paths and commit them with a Conventional Commits subject derived from the diff. Pick the type from the work itself: `feat:` for new functionality, `fix:` for bugfixes, `refactor:` for restructuring without behavior change, `docs:` for documentation, `style:` for formatting, `test:` for tests, `perf:` for performance, `build:` for build-system changes, `ci:` for CI configuration, `chore:` for everything else. Only `feat:` and `fix:` drive a release-please bump, so misclassifying functional work as `chore:` silently skips its release. Do not use a `wip:` placeholder. Do not run `git add -A` blindly; stage by explicit path so untracked files are added intentionally.
    - If a path should be excluded from the PR, the user must add it to `.gitignore` or stash it before `/pr` continues. The skill does not stash silently.
    - If the working tree is clean, skip the commit and continue. The branch must already have implementation commits ahead of `$BASE_BRANCH` (verified in step 6).
 
@@ -39,7 +39,7 @@ Single command to go from "I'm done" to "PR is open."
 
 5. **Stage and commit auto-fixed files**:
    - Check `git status` for changes from formatting
-   - If there are changes: stage them, commit with message "Auto-format and lint fixes". This is a separate commit from the implementation commit in step 2.
+   - If there are changes: stage them, commit with message `style: auto-format and lint fixes`. This is a separate commit from the implementation commit in step 2.
    - If no changes: skip
 
 6. **Pre-push gate** (build the publication inventory before any push):

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -20,7 +20,7 @@ Complete the current branch by committing, pushing, merging, and cleaning up.
    ```
 
 1. **Review uncommitted changes**: Run `git status` and `git diff` to see what's uncommitted. If any files or changes look suspect, prompt the user and wait for confirmation before committing.
-2. **Commit**: Stage and commit the confirmed changes with a descriptive message based on the diff.
+2. **Commit**: Stage and commit the confirmed changes with a Conventional Commits subject based on the diff. Pick the type from the work itself: `feat:` for new functionality, `fix:` for bugfixes, `refactor:` for restructuring without behavior change, `docs:` for documentation, `style:` for formatting, `test:` for tests, `perf:` for performance, `build:` for build-system changes, `ci:` for CI configuration, `chore:` for everything else. Only `feat:` and `fix:` drive a release-please bump, so misclassifying functional work as `chore:` silently skips its release.
 3. **Pre-push gate** (build the publication inventory before any push):
 
    ```bash

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -146,7 +146,7 @@ Apply all safe (minor/patch, non-CVE) dependencies in a single batch per manifes
 3. If tests pass, commit all safe updates in one commit per manifest, listing the updated deps:
 
 ```
-Update minor/patch dependencies
+chore(deps): update minor/patch dependencies
 
 - axios 1.6.0 -> 1.7.2
 - dotenv 16.3.1 -> 16.4.1
@@ -369,7 +369,7 @@ Non-CVE major bumps that get reverted stay out of this file. They surface under 
 One atomic commit per dependency:
 
 ```
-Update express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX)
+fix(deps): update express 4.18.2 to 5.1.0 (CVE-2024-XXXXX)
 
 Breaking changes addressed:
 - req.host -> req.hostname (proxy.ts, health.ts)
@@ -378,14 +378,14 @@ Breaking changes addressed:
 Migration guide: https://expressjs.com/en/guide/migrating-5.html
 ```
 
-For non-CVE major bumps, omit the CVE reference from the subject line.
+CVE-driven dep bumps use `fix(deps):` because they are functional fixes that should drive a release-please patch bump. For non-CVE major bumps, use `chore(deps):` and omit the CVE reference from the subject line.
 
 ### 7g. Repeat for the next change plan
 
 ## Step 8: Final Validation
 
 1. Run the full test suite to catch interaction effects between independently applied updates.
-2. Run the project's linter and formatter (check CLAUDE.md for commands). If auto-fixes are applied, commit them separately with message `Auto-format and lint fixes`.
+2. Run the project's linter and formatter (check CLAUDE.md for commands). If auto-fixes are applied, commit them separately with message `style: auto-format and lint fixes`.
 3. If the final test suite fails, identify which combination of updates caused the interaction and report it to the user.
 
 ## Step 9: Cleanup and Summary

--- a/tests/test_conventional_commit_templates.py
+++ b/tests/test_conventional_commit_templates.py
@@ -1,0 +1,322 @@
+"""Conventional Commits validator for workflow skill templates.
+
+The repo's release pipeline (release-please, configured in
+``release-please-config.json`` and documented in ``AGENTS.md`` under
+"Commits and releases") only bumps versions on commits whose subjects start
+with ``feat:`` or ``fix:`` and silently ignores other types. Workflow
+skills (``pr``, ``ship``, ``next-ticket``, ``update-deps``,
+``convert-worktree``) are the surfaces an AFK agent uses to produce
+commits, so any non-Conventional-Commits subject template they emit will
+slip past release-please without bumping the version.
+
+This validator scans every ``skills/*/SKILL.md`` for commit-subject
+templates in the two shapes the skills actually use:
+
+1. Quoted subjects in shell snippets, e.g. ``git commit -m "..."``.
+2. First lines of fenced code blocks whose first line looks like a
+   Conventional-Commits-shaped subject (a single short line followed by a
+   blank line and a body), as ``update-deps`` uses for its per-dep major
+   bump example and its safe-update batch commit.
+3. Backtick-wrapped subjects in prose where the sentence cues the string
+   as a commit subject ("commit ... message" within a small window).
+
+Acceptable types: ``feat``, ``fix``, ``chore``, ``refactor``, ``docs``,
+``style``, ``test``, ``perf``, ``build``, ``ci``, ``revert``. Optional
+``(scope)`` and optional ``!`` for breaking changes are allowed.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+
+CONVENTIONAL_TYPES = (
+    "feat",
+    "fix",
+    "chore",
+    "refactor",
+    "docs",
+    "style",
+    "test",
+    "perf",
+    "build",
+    "ci",
+    "revert",
+)
+
+CONVENTIONAL_PREFIX_RE = re.compile(
+    r"^(" + "|".join(CONVENTIONAL_TYPES) + r")(\([^)]+\))?!?:\s"
+)
+
+
+def is_conventional(subject):
+    """Return True iff ``subject`` starts with a Conventional Commits type."""
+    return bool(CONVENTIONAL_PREFIX_RE.match(subject))
+
+
+def strip_frontmatter(text):
+    match = re.match(r"^---\n.*?\n---\n", text, re.DOTALL)
+    return text[match.end():] if match else text
+
+
+def public_skill_files():
+    return sorted(SKILLS_DIR.glob("*/SKILL.md"))
+
+
+# Shape 1: ``git commit -m "<subject>"``. The subject is everything inside
+# the matched quotes on the same line.
+GIT_COMMIT_DASH_M_RE = re.compile(
+    r"""git\s+commit\s+(?:[^"'\n]*\s+)?-m\s+(?P<q>["'])(?P<subject>.+?)(?P=q)"""
+)
+
+
+# Shape 2: a fenced code block that opens with a single short line that
+# looks like a commit subject (no leading shell prompt, no backtick, no
+# JSON/YAML markers), followed by an empty line and a body. We only fire
+# on blocks whose first non-blank line "looks like" a commit subject by
+# being short, on its own line, and not a code/markup token. The
+# disambiguation criteria below are deliberately strict to avoid false
+# positives on shell or JSON snippets.
+FENCED_BLOCK_RE = re.compile(
+    r"^```(?P<lang>[^\n]*)\n(?P<body>.*?)^```",
+    re.DOTALL | re.MULTILINE,
+)
+
+# Languages whose blocks are never commit-subject templates.
+NON_COMMIT_BLOCK_LANGS = {
+    "bash",
+    "sh",
+    "shell",
+    "zsh",
+    "console",
+    "json",
+    "jsonc",
+    "yaml",
+    "yml",
+    "toml",
+    "ini",
+    "python",
+    "py",
+    "javascript",
+    "js",
+    "typescript",
+    "ts",
+    "tsx",
+    "go",
+    "rust",
+    "rs",
+    "java",
+    "kotlin",
+    "ruby",
+    "rb",
+    "php",
+    "html",
+    "css",
+    "diff",
+    "patch",
+    "dockerfile",
+    "makefile",
+    "xml",
+    "sql",
+}
+
+
+def looks_like_commit_subject_block(body):
+    """Heuristic: is this fenced block a commit-message template?
+
+    A commit-message template has:
+    - A first line under 100 chars that is NOT a shell prompt, JSON/YAML
+      structural token, or summary header,
+    - Followed by an empty line and at least one further content line OR is
+      the entire block (single-line subject template).
+
+    We restrict positives to blocks whose first line is plausibly a commit
+    subject and whose body content reads as a commit body (bullets, blank
+    lines, plain prose) rather than a CLI session or summary report.
+    """
+    lines = body.splitlines()
+    if not lines:
+        return False
+    first = lines[0].rstrip()
+    if not first:
+        return False
+    if len(first) > 100:
+        return False
+    # Reject obvious non-subject first lines.
+    rejects = (
+        first.startswith("$"),
+        first.startswith("#"),
+        first.startswith("//"),
+        first.startswith("/*"),
+        first.startswith("{"),
+        first.startswith("["),
+        first.startswith("- "),
+        first.startswith("* "),
+        first.startswith("> "),
+        first.startswith("|"),
+        first.endswith(":") and " " not in first.split(":")[0],
+        first.endswith("."),
+    )
+    if any(rejects):
+        return False
+    # The first line must contain at least one space (commit subjects are
+    # multi-word) and must not look like a key/value or assignment.
+    if "=" in first and ":" not in first:
+        return False
+    # Blocks that are entire summary reports start with a sentence ending
+    # in a period; we already rejected period endings above, but also
+    # screen for "<word> <word> ..." lines that read as report headers.
+    # A commit subject either has a Conventional prefix OR is a short
+    # imperative phrase. To keep the heuristic narrow, only treat the
+    # block as a commit subject when:
+    #   (a) the first line itself matches the Conventional regex, OR
+    #   (b) the block body contains a "Migration guide:" /
+    #       "Breaking changes" cue or a leading bullet list immediately
+    #       under the subject (the shape of the templates this validator
+    #       guards).
+    if is_conventional(first):
+        return True
+    has_blank_then_bullet = (
+        len(lines) >= 3
+        and lines[1].strip() == ""
+        and (lines[2].lstrip().startswith("- ") or lines[2].lstrip().startswith("* "))
+    )
+    has_known_cue = any(
+        cue in body
+        for cue in ("Migration guide:", "Breaking changes addressed:")
+    )
+    return has_blank_then_bullet or has_known_cue
+
+
+# Shape 3: prose mention of a commit subject in backticks or quotes,
+# within a sentence that names "commit" and "message". Window is one
+# sentence (no period in between).
+PROSE_COMMIT_REF_RE = re.compile(
+    r"commit[^.\n`\"]{0,80}?(?:message|subject)[^.\n`\"]{0,40}?"
+    r"[`\"](?P<subject>[^`\"\n]{3,120})[`\"]",
+    re.IGNORECASE,
+)
+
+
+def commit_subject_candidates(body):
+    """Yield (kind, subject, context) for every commit-subject candidate."""
+    # Shape 1: git commit -m "..."
+    for match in GIT_COMMIT_DASH_M_RE.finditer(body):
+        yield ("git-commit-dash-m", match.group("subject"), match.group(0))
+
+    # Shape 2: fenced commit-template blocks
+    for match in FENCED_BLOCK_RE.finditer(body):
+        lang = match.group("lang").strip().lower()
+        if lang in NON_COMMIT_BLOCK_LANGS:
+            continue
+        block_body = match.group("body")
+        if not looks_like_commit_subject_block(block_body):
+            continue
+        first_line = block_body.splitlines()[0].rstrip()
+        yield ("fenced-block-subject", first_line, match.group(0))
+
+    # Shape 3: prose backtick/quoted commit refs
+    for match in PROSE_COMMIT_REF_RE.finditer(body):
+        yield ("prose-quoted-commit", match.group("subject"), match.group(0))
+
+
+class ConventionalCommitTemplatesTest(unittest.TestCase):
+    def test_skill_commit_subjects_are_conventional(self):
+        any_candidates_found = False
+        for skill_path in public_skill_files():
+            skill_name = skill_path.parent.name
+            body = strip_frontmatter(skill_path.read_text())
+            for kind, subject, context in commit_subject_candidates(body):
+                any_candidates_found = True
+                with self.subTest(skill=skill_name, kind=kind, subject=subject):
+                    self.assertTrue(
+                        is_conventional(subject),
+                        f"{skill_name}: {kind} subject is not a Conventional "
+                        f"Commits prefix.\n"
+                        f"  Subject: {subject!r}\n"
+                        f"  Context: {context[:200]}\n"
+                        f"  Allowed types: {', '.join(CONVENTIONAL_TYPES)}\n"
+                        f"  Note: only feat: and fix: trigger a release-"
+                        f"please bump; other types are valid Conventional "
+                        f"Commits but produce no release.",
+                    )
+        # Sanity check: the validator should be exercising at least one
+        # template in the current repo. If this trips, the candidate
+        # detection has regressed.
+        self.assertTrue(
+            any_candidates_found,
+            "Validator found zero commit-subject candidates across all "
+            "skills. Detection has regressed.",
+        )
+
+    def test_regex_self_test(self):
+        # Conventional subjects must pass.
+        for subject in (
+            "feat: add x",
+            "fix: correct y",
+            "chore(deps): update minor/patch dependencies",
+            "fix(deps): update express 4.18.2 to 5.1.0 (CVE-2024-XXXXX)",
+            "style: auto-format and lint fixes",
+            "chore(worktree): preserve tracked changes during conversion",
+            "refactor!: rename public API",
+            "feat(api)!: drop legacy endpoint",
+        ):
+            with self.subTest(subject=subject):
+                self.assertTrue(is_conventional(subject))
+
+        # Non-Conventional subjects must fail. Each of these is a literal
+        # template that previously appeared in a workflow skill on main.
+        for subject in (
+            "Auto-format and lint fixes",
+            "Update minor/patch dependencies",
+            "wip: tracked changes from worktree conversion",
+            "Update express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX)",
+            "WIP: anything",
+            "fixed a bug",
+        ):
+            with self.subTest(subject=subject):
+                self.assertFalse(is_conventional(subject))
+
+    def test_candidate_detection_self_test(self):
+        # The validator must catch the previously-shipped non-Conventional
+        # templates from main when they are reintroduced. This guards the
+        # detector itself from silently going blind.
+        regression_sample = (
+            'Run `git commit -m "Auto-format and lint fixes"` in step 5.\n'
+            "\n"
+            "```\n"
+            "Update minor/patch dependencies\n"
+            "\n"
+            "- axios 1.6.0 -> 1.7.2\n"
+            "```\n"
+            "\n"
+            "Then commit with message `wip: tracked changes from worktree "
+            "conversion`.\n"
+            "\n"
+            "```\n"
+            "Update express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX)\n"
+            "\n"
+            "Breaking changes addressed:\n"
+            "- foo\n"
+            "\n"
+            "Migration guide: https://example.com\n"
+            "```\n"
+        )
+        candidates = list(commit_subject_candidates(regression_sample))
+        subjects = [subject for _, subject, _ in candidates]
+        self.assertIn("Auto-format and lint fixes", subjects)
+        self.assertIn("Update minor/patch dependencies", subjects)
+        self.assertIn("wip: tracked changes from worktree conversion", subjects)
+        self.assertIn("Update express 4.18.2 -> 5.1.0 (CVE-2024-XXXXX)", subjects)
+        # And every one of those must fail the Conventional check.
+        for subject in subjects:
+            with self.subTest(subject=subject):
+                self.assertFalse(is_conventional(subject))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replaces non-conventional commit-message templates and prose instructions across `skills/pr`, `skills/ship`, `skills/update-deps`, `skills/convert-worktree`, and `skills/next-ticket` so the messages these skills generate match the Conventional Commits format that `release-please` keys on.

Today the skills emit subjects release-please silently skips for bump purposes (`Auto-format and lint fixes`, `Update minor/patch dependencies`, `wip: tracked changes from worktree conversion`), and the prose-derived implementation commits don't constrain format. AFK reviewers won't catch the drift.

## Replacements
- `Auto-format and lint fixes` -> `style: auto-format and lint fixes`
- `Update minor/patch dependencies` -> `chore(deps): update minor/patch dependencies`
- `wip: tracked changes from worktree conversion` -> `chore(worktree): preserve tracked changes during conversion`
- Per-dep major-bump example -> `fix(deps): update express 4.18.2 to 5.1.0 (CVE-2024-XXXXX)` (uses `to` instead of `->` so the subject doesn't read like a shell redirection)
- Prose for `pr`, `ship`, `next-ticket` now requires Conventional Commits format with the type-selection rule documented inline, including a one-line note that only `feat:` and `fix:` drive release-please bumps.

A new validator at `tests/test_conventional_commit_templates.py` scans every skill body and asserts no template subject starts with a non-conventional prefix.

Design doc: `docs/superpowers/specs/2026-04-26-conventional-commit-consistency-design.md`.

## Tests
\`python3 -m unittest discover tests\` reports the full suite passing.