### PR TITLE
next-ticket support for specific ticket (skip eval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of skills for agentic coding tools, including [Claude Code](https:/
 
 | | Skill | Command | What it does |
 |---|-------|---------|-------------|
-| **Tickets** | [next-ticket](#next-ticket) | `/next-ticket` | Pick the best open ticket, implement it with TDD, wait for review |
+| **Tickets** | [next-ticket](#next-ticket) | `/next-ticket [id]` | Pick up a ticket (best open or specific), implement it with TDD, wait for review |
 | | [triage-architecture](#triage-architecture) | `/triage-architecture` | Audit code for structural/safety issues; file tickets or `refine` existing |
 | | [triage-bugs](#triage-bugs) | `/triage-bugs` | Prove real defects with 4-pass analysis; file or `refine` what clears the bar |
 | | [triage-product](#triage-product) | `/triage-product` | Audit UX for broken workflows/gaps; file tickets or `refine` existing |
@@ -89,9 +89,9 @@ The triage skills learn from the tickets you reject. When closing a ticket becau
 
 ### [next-ticket](skills/next-ticket/SKILL.md)
 
-Picks the highest-value open ticket from your issue tracker, implements it end-to-end with TDD, and waits for your review. Tickets are scored by severity, simplicity, blocking power, and value. Before branching, the skill validates the ticket against current code (checking for prior fixes or partial resolution) and claims it with a team-safe self-assignment protocol: re-reads the assignee field after a randomized pause to avoid collisions, self-assigns, and confirms the read-back matches before proceeding.
+Picks up a ticket from your issue tracker, implements it end-to-end with TDD, and waits for your review. With no argument, it fetches all eligible tickets, scores them by severity, simplicity, blocking power, and value, and picks the best candidate. With a ticket ID argument, it fetches that specific ticket directly and skips scoring. In both modes, the skill validates the ticket against current code (checking for prior fixes or partial resolution) and claims it with a team-safe self-assignment protocol: re-reads the assignee field after a randomized pause to avoid collisions, self-assigns, and confirms the read-back matches before proceeding.
 
-**Usage:** `/next-ticket`
+**Usage:** `/next-ticket` (auto-pick best ticket) or `/next-ticket 42` (pick up a specific ticket). Ticket IDs are resolved flexibly: bare numbers are interpreted per platform (e.g., `42` becomes `ABC-42` on Jira if the project key is known), and prefixed IDs like `#42` or `ABC-42` are used as-is.
 
 **Triage skills** share the same architecture: cache tickets to disk, build a project map, spawn 4 parallel sub-agents (one per concern cluster), and post-process cross-cluster findings. Each supports three modes:
 

--- a/skills/next-ticket/SKILL.md
+++ b/skills/next-ticket/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: next-ticket
-description: Use when looking for the next ticket to work on. Detects the project's ticket system (GitHub Issues, Jira, GitLab Issues, Azure Boards, etc.), fetches open tickets that are unassigned or assigned to you, scores by severity/simplicity/value/blocking-power/dependencies, picks the best candidate, claims it by self-assigning (team-safe), branches, implements, tests, formats, and waits for review with a UI testing tip.
+description: Use when looking for the next ticket to work on. Detects the project's ticket system (GitHub Issues, Jira, GitLab Issues, Azure Boards, etc.), fetches open tickets that are unassigned or assigned to you, scores by severity/simplicity/value/blocking-power/dependencies, picks the best candidate, claims it by self-assigning (team-safe), branches, implements, tests, formats, and waits for review with a UI testing tip. Accepts an optional ticket ID argument (e.g., `/next-ticket 42`, `/next-ticket PROJ-42`) to skip evaluation and pick up a specific ticket directly.
 ---
 
 # Next Ticket
 
-Pick the highest-value open ticket, implement it end-to-end, and wait for review.
+Pick up a ticket, implement it end-to-end, and wait for review.
+
+## Arguments
+
+| Arg | Required | Description |
+|-----|----------|-------------|
+| `ticket-id` | No | A specific ticket identifier (e.g., `42`, `#42`, `PROJ-42`). When provided, Step 2 fetches only this ticket instead of the full open-ticket list, and Step 3 skips scoring and ranking. All other steps, including identity resolution, claiming, branching, TDD, implementation, and review, apply unchanged. |
+
+The argument is interpreted flexibly based on the detected ticket system:
+
+- **Bare number** (e.g., `42`): For GitHub/GitLab, use as the issue number directly. For Jira, prepend the project key resolved during ticket-system detection (e.g., if the detected Jira project is `ABC`, treat `42` as `ABC-42`). For Azure Boards, use the work item ID.
+- **Prefixed ID** (e.g., `#42`, `ABC-42`, `AB#42`): Use as-is after stripping syntax that the CLI doesn't accept (e.g., strip `#` for `gh issue view 42`).
+- **Ambiguous**: If the ticket system expects a project prefix and neither the argument nor the cached config supplies one, attempt to infer the project key from repo signals (commit messages, branch names, config files, ticket templates) and try fetching with that prefix first. If the fetch fails, ask the user for the project key, then cache it in `next-ticket-config.json` alongside the ticket-system entry for this project root so future bare-number invocations resolve automatically.
 
 ## Prerequisites
 
@@ -59,7 +71,13 @@ Resolve identity in this order:
 
 If the per-system handle cannot be resolved (discovery fails and the user declines to supply one), stop with a clear message. Running without identity on a shared repo recreates the exact collision this skill is meant to prevent; there is no safe silent fallback.
 
-## Step 2: Fetch Open Tickets
+## Step 2: Fetch Tickets
+
+### Direct-pick mode (ticket ID argument provided)
+
+Fetch only the specified ticket's full data (title, body, labels, assignees, comments, status) using whatever CLI, MCP, or API tooling fits the detected system (e.g., `gh issue view <id> --json title,body,labels,assignees,comments` for GitHub). Normalize it into the same shape shown below. Do not fetch the broader open-ticket list or recently closed tickets. If the ticket does not exist or cannot be fetched, tell the user and stop. **Proceed to Step 3** (scoring is skipped internally; announcement still applies).
+
+### Auto-pick mode (no argument)
 
 Using whatever CLI tools, MCP tools, or APIs are available in the current session, fetch open tickets that are **either unassigned or assigned to the current user's per-system handle** from Step 1b. Prefer the system's native server-side filter; fall back to fetching all open tickets and filtering locally against the stored handle.
 
@@ -70,7 +88,13 @@ Using whatever CLI tools, MCP tools, or APIs are available in the current sessio
 - Azure Boards: `az boards work-item list` with a WIQL filter using `@Me` and `[System.AssignedTo] = ''`.
 - Other: Use whatever is available. If no tool is found, tell the user what to install and stop.
 
-Normalize the fetched data into this shape (write to a temp file):
+Also fetch recently closed/resolved tickets (titles and IDs only) to understand what's already been done.
+
+If zero open tickets, tell the user and stop.
+
+### Normalized shape
+
+Normalize the fetched data (both modes) into this shape (write to a temp file):
 
 ```json
 [
@@ -86,11 +110,9 @@ Normalize the fetched data into this shape (write to a temp file):
 ]
 ```
 
-Also fetch recently closed/resolved tickets (titles and IDs only) to understand what's already been done.
-
-If zero open tickets, tell the user and stop.
-
 ## Step 3: Score and Rank
+
+> **Direct-pick mode:** Skip scoring and ranking. Proceed directly to Announce Selection below with the fetched ticket as the selected candidate.
 
 Read every ticket's title, full body, labels, and comments. Build a mental scorecard for each ticket using these factors:
 
@@ -115,13 +137,23 @@ Read every ticket's title, full body, labels, and comments. Build a mental score
 
 ### Announce Selection
 
-Print a brief rationale, formatting the ticket ID according to the platform (e.g., `#42` for GitHub/GitLab, `PROJ-42` for Jira, `42` for Azure Boards):
+Print the selected ticket before validation begins. Format the ticket ID according to the platform (e.g., `#42` for GitHub/GitLab, `PROJ-42` for Jira, `42` for Azure Boards).
+
+**Auto-pick mode** prints scoring factors:
 
 ```
 Selected: <ticket-id> - "Fix auth token refresh race condition"
   Severity: high | Simplicity: focused (single file) | Blocks: <id>, <id>
   Assignee: unassigned | already yours
   Reason: Highest severity, clear fix direction, unblocks two other tickets.
+```
+
+**Direct-pick mode** prints a shorter announcement:
+
+```
+Selected: <ticket-id> - "<ticket title>"
+  Assignee: <unassigned | already yours | assigned to <someone>>
+  Reason: user-selected
 ```
 
 ## Step 4: Validate Against Current Code
@@ -136,21 +168,23 @@ Before branching, verify the selected ticket is still valid on the latest codeba
    - **Refactors/chores**: Is the target code still in the state described?
 4. **Verdict:**
    - **Still valid**: proceed to Step 5.
-   - **100% resolved**: All items in the ticket are addressed. Mark as resolved with a comment explaining what you found, then loop back to Step 3 and pick the next candidate.
-   - **Partially resolved**: Some items remain. You have two options:
-     - **Work on it**: If the remaining work is a good candidate (simple, high-value), proceed to Step 5.
-     - **Refine and skip**: If you'd rather pick a different ticket, do NOT close this one. Instead, edit the ticket body to remove completed items (keep only remaining work), update the title to reflect the narrower scope, add a comment summarizing what was already done, then loop back to Step 3. The refined ticket becomes eligible for future iterations.
+   - **100% resolved**: All items in the ticket are addressed. Mark as resolved with a comment explaining what you found. In auto-pick mode, loop back to Step 3 and pick the next candidate. In direct-pick mode, tell the user the ticket is already resolved and stop.
+   - **Partially resolved**: Some items remain.
+     - **Direct-pick mode**: Always work on the remaining items. Proceed to Step 5.
+     - **Auto-pick mode**: You have two options:
+       - **Work on it**: If the remaining work is a good candidate (simple, high-value), proceed to Step 5.
+       - **Refine and skip**: If you'd rather pick a different ticket, do NOT close this one. Instead, edit the ticket body to remove completed items (keep only remaining work), update the title to reflect the narrower scope, add a comment summarizing what was already done, then loop back to Step 3. The refined ticket becomes eligible for future iterations.
    - **Can't determine**: proceed with caution and note uncertainty.
 
-> **Do not claim during a refine-and-skip pass.** Claiming happens once, in Step 4.5, on the final selection only.
+> **Auto-pick mode: do not claim during a refine-and-skip pass.** Claiming happens once, in Step 4.5, on the final selection only. (Refine-and-skip does not apply in direct-pick mode.)
 
 ## Step 4.5: Claim the Ticket
 
 Before branching or writing code, self-assign the selected ticket in the source system. This is the point where work becomes visible to teammates and where a last-second race check cuts the chance of two people picking the same ticket.
 
 1. **Re-read the assignee.** Fetch the selected ticket's current assignee from the source system. This is a fresh read, not cached data from Step 2. A brief randomised pause (0-500ms) before the read helps desynchronise two teammates running simultaneously.
-2. **Foreign-owned now?** If the ticket has just been assigned to someone else, abandon this candidate, note it in one line, and loop back to Step 3 to pick the next.
-3. **Unassigned?** Self-assign using the handle stored under `__user__.usernames[<system>]`. Use whatever CLI, MCP, or API tooling fits the system (e.g., `gh issue edit <id> --add-assignee <handle>` for GitHub). Then read the ticket back once and confirm the assignee matches your handle. If the read-back shows someone else, treat it as a lost race and loop back to Step 3.
+2. **Foreign-owned now?** If the ticket has just been assigned to someone else: in auto-pick mode, abandon this candidate, note it in one line, and loop back to Step 3 to pick the next. In direct-pick mode, tell the user the ticket was just claimed by someone else and stop.
+3. **Unassigned?** Self-assign using the handle stored under `__user__.usernames[<system>]`. Use whatever CLI, MCP, or API tooling fits the system (e.g., `gh issue edit <id> --add-assignee <handle>` for GitHub). Then read the ticket back once and confirm the assignee matches your handle. If the read-back shows someone else, treat it as a lost race: in auto-pick mode, loop back to Step 3. In direct-pick mode, tell the user and stop.
 4. **Already yours?** Skip the write. Proceed.
 5. **Assignment failed?** If the tool is missing, permissions are denied, or the write errors out, stop with a clear, specific message. Do not start work on a ticket you couldn't claim.
 
@@ -284,12 +318,12 @@ The UI testing tip must be **specific and actionable**, not "test the feature" b
 
 - **Never push or create PRs.** The user reviews first.
 - **Never skip tests.** AFK implementation demands high confidence.
-- **Never pick a ticket assigned to someone else.** Unassigned and already-yours are both eligible; anything with another person on it is off-limits.
-- **Never pick a ticket with unmet dependencies.** It can't be completed.
+- **Never pick a ticket assigned to someone else.** Unassigned and already-yours are both eligible; anything with another person on it is off-limits. In direct-pick mode, the user's explicit selection overrides this: warn that the ticket is assigned to someone else and ask for confirmation before proceeding.
+- **Never pick a ticket with unmet dependencies.** It can't be completed. In direct-pick mode, the user's explicit selection overrides this: warn about unmet dependencies and ask for confirmation before proceeding.
 - **Claim after validating, before branching.** Step 4.5 is the only claim point. Re-read the assignee at the top of it so the race window stays small, and don't claim during a Step 4 refine-and-skip pass.
 - **No identity, no run.** If the per-system handle can't be resolved and the user won't supply one, stop. Running unfiltered on a shared repo recreates the collision this skill is meant to prevent.
-- **Validation (Step 4): refine, don't close.** If a ticket has remaining work, edit the ticket to reflect only what remains (update title and body), then move to the next candidate. Never close a ticket that isn't 100% resolved.
-- **Implementation (Steps 5-9): fully implement.** Once you pick a ticket, complete it entirely. No partial commits, no WIP commits, no handoffs. The scoring in Step 3 filters for simplicity and clarity precisely so that picked tickets can be fully implemented touch-free.
+- **Validation (Step 4): refine, don't close.** If a ticket has remaining work and you choose to skip it (auto-pick only), edit the ticket to reflect only what remains (update title and body), then move to the next candidate. In direct-pick mode, always work on remaining items. Never close a ticket that isn't 100% resolved.
+- **Implementation (Steps 5-9): fully implement.** Once you pick a ticket, complete it entirely. No partial commits, no WIP commits, no handoffs. In auto-pick mode, the scoring in Step 3 filters for simplicity and clarity so that picked tickets can be fully implemented touch-free. In direct-pick mode, the user accepted this responsibility by choosing the ticket.
 - **Auto-review (Step 9.5): non-blocking.** The code-review subagent runs automatically before Step 10. If dispatch fails or the capability is unavailable, the review is recorded as skipped and the workflow continues; it never halts the run.
-- **If no suitable ticket exists** (all assigned to others, all blocked, none clear enough for AFK), tell the user and stop.
+- **If no suitable ticket exists** (auto-pick only: all assigned to others, all blocked, none clear enough for AFK), tell the user and stop.
 - **Clean up temp files** when done.


### PR DESCRIPTION
This pull request updates the `/next-ticket` skill to support picking up a specific ticket by ID, in addition to the existing auto-pick mode. The documentation is revised throughout to clarify the new argument, how ticket IDs are resolved for different platforms, and how the workflow adapts for direct-pick versus auto-pick. Several behavioral details and edge cases are now explicitly documented.

**Key changes:**

**1. Feature: Direct Ticket Selection**
- `/next-ticket` now accepts an optional ticket ID argument (e.g., `/next-ticket 42`, `/next-ticket PROJ-42`) to fetch and work on a specific ticket directly, bypassing scoring and ranking. The argument is flexibly interpreted depending on the ticket system (GitHub, Jira, etc.). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7) [[2]](diffhunk://#diff-921fa0bca5981f01fabd93c98e93b5f4c63cd00005b7cbaa12b9844d5b4e7dc9L3-R20)

**2. Workflow and Behavior Adjustments**
- The workflow is split into "auto-pick" (no argument, scores all open tickets) and "direct-pick" (ticket ID provided, fetches only that ticket and skips scoring). Documentation now explains how each step adapts in both modes, including how to handle resolved, partially resolved, or newly assigned tickets. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R94) [[2]](diffhunk://#diff-921fa0bca5981f01fabd93c98e93b5f4c63cd00005b7cbaa12b9844d5b4e7dc9L62-R80) [[3]](diffhunk://#diff-921fa0bca5981f01fabd93c98e93b5f4c63cd00005b7cbaa12b9844d5b4e7dc9L89-R116) [[4]](diffhunk://#diff-921fa0bca5981f01fabd93c98e93b5f4c63cd00005b7cbaa12b9844d5b4e7dc9L139-R187)
- In direct-pick mode, the user is warned and asked for confirmation if the ticket is assigned to someone else or has unmet dependencies, overriding the default auto-pick restrictions.

**3. Output and Messaging**
- Selection announcement is now mode-specific: auto-pick includes scoring rationale, while direct-pick prints a concise summary and notes that the ticket was user-selected. [[1]](diffhunk://#diff-921fa0bca5981f01fabd93c98e93b5f4c63cd00005b7cbaa12b9844d5b4e7dc9L118-R142) [[2]](diffhunk://#diff-921fa0bca5981f01fabd93c98e93b5f4c63cd00005b7cbaa12b9844d5b4e7dc9R151-R158)

**4. Platform-specific Ticket ID Resolution**
- The documentation details how bare numbers and prefixed IDs are resolved for different ticket systems, and how ambiguous cases are handled by prompting the user and caching their input for future runs.

**5. Documentation Consistency and Clarity**
- The `README.md` and `SKILL.md` files are updated throughout to clarify command usage, argument handling, and the step-by-step workflow for both modes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R94) [[3]](diffhunk://#diff-921fa0bca5981f01fabd93c98e93b5f4c63cd00005b7cbaa12b9844d5b4e7dc9L3-R20)

These changes make the `/next-ticket` skill more flexible and user-friendly, allowing both guided ticket selection and direct assignment as needed.