### PR TITLE
docs: strengthen README clarity and visual hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A collection of skills for agentic coding tools, including [Claude Code](https:/
 
 | | Skill | Command | What it does |
 |---|-------|---------|-------------|
-| **Tickets** | [create-ticket](#create-ticket) | `/create-ticket [idea]` | Research an idea, craft a high-quality ticket, dedup, and file it |
+| **Ticket** | [create-ticket](#create-ticket) | `/create-ticket [idea]` | Research an idea, craft a high-quality ticket, dedup, and file it |
 | | [next-ticket](#next-ticket) | `/next-ticket [id]` | Pick up a ticket (best open or specific), implement it with TDD, wait for review |
-| | [triage-architecture](#triage-architecture) | `/triage-architecture` | Audit code for structural/safety issues; file tickets or `refine` existing |
-| | [triage-bugs](#triage-bugs) | `/triage-bugs` | Prove real defects with 4-pass analysis; file or `refine` what clears the bar |
-| | [triage-product](#triage-product) | `/triage-product` | Audit UX for broken workflows/gaps; file tickets or `refine` existing |
+| | [triage-architecture](#triage-architecture) | `/triage-architecture` | Find structural/safety issues in code; file tickets or `refine` existing |
+| | [triage-bugs](#triage-bugs) | `/triage-bugs` | Prove real defects with 4-pass analysis; file tickets or `refine` existing |
+| | [triage-product](#triage-product) | `/triage-product` | Find UX gaps and broken workflows; file tickets or `refine` existing |
 | **Quality** | [code-review](#code-review) | `/code-review` | Dispatch a reviewer subagent to evaluate all branch work (committed + uncommitted) |
 | | [apply-review](#apply-review) | `/apply-review` | Read PR review comments, fix valid ones, push, resolve addressed threads |
 | | [get-it-right](#get-it-right) | `/get-it-right` | Re-architect the current branch from scratch, leave unstaged for review |
@@ -18,11 +18,14 @@ A collection of skills for agentic coding tools, including [Claude Code](https:/
 | **Utility** | [compress-markdown](#compress-markdown) | `/compress-markdown` | Compress markdown to save tokens; `deep` validates against codebase first |
 | | [update-deps](#update-deps) | `/update-deps` | Check CVEs, apply minor/patch updates, `major` for breaking changes; scopeable |
 
+---
+
 ## Installation
 
-Installation differs by platform. All three platforms consume the same `skills/<name>/SKILL.md` format, so one install gets you every skill.
+> Installation differs by platform. All three platforms consume the same `skills/<name>/SKILL.md` format, so one install gets you every skill.
 
-### Claude Code
+<details>
+<summary>Claude Code</summary>
 
 Register the marketplace, then install the plugin:
 
@@ -31,7 +34,10 @@ Register the marketplace, then install the plugin:
 /plugin install agentic-toolkit@agentic-marketplace
 ```
 
-### Codex
+</details>
+
+<details>
+<summary>Codex</summary>
 
 See [.codex/INSTALL.md](.codex/INSTALL.md). Short version:
 
@@ -43,7 +49,10 @@ ln -s ~/.codex/agentic-toolkit/skills ~/.agents/skills/agentic-toolkit
 
 Restart Codex to discover the skills.
 
-### Gemini CLI
+</details>
+
+<details>
+<summary>Gemini CLI</summary>
 
 ```bash
 gemini extensions install https://github.com/adamcaviness/agentic-toolkit
@@ -51,92 +60,119 @@ gemini extensions install https://github.com/adamcaviness/agentic-toolkit
 
 Update with `gemini extensions update agentic-toolkit`.
 
-<details>
-<summary>Manual symlink install (any platform)</summary>
+</details>
 
-If you prefer not to use a plugin/extension system, symlink the skill directories directly.
+<details>
+<summary>Manual (any platform)</summary>
+
+If you prefer not to use a plugin/extension system, clone the repo and symlink the skill directories.
 
 ```bash
+git clone https://github.com/adamcaviness/agentic-toolkit.git ~/opensource/agentic-toolkit
+
+
 # Claude Code (user-level)
-for skill in /path/to/agentic-toolkit/skills/*/; do
+for skill in ~/opensource/agentic-toolkit/skills/*/; do
   ln -s "$skill" ~/.claude/skills/"$(basename "$skill")"
 done
 
 # Codex (user-level)
-for skill in /path/to/agentic-toolkit/skills/*/; do
+for skill in ~/opensource/agentic-toolkit/skills/*/; do
   ln -s "$skill" ~/.agents/skills/"$(basename "$skill")"
 done
 ```
 
-For a single skill: `ln -s /path/to/agentic-toolkit/skills/next-ticket ~/.claude/skills/next-ticket`.
+For a single skill: `ln -s ~/opensource/agentic-toolkit/skills/next-ticket ~/.claude/skills/next-ticket`.
 
 For project-level install, symlink into `.claude/skills/` or `.agents/skills/` inside the project root.
 
 </details>
 
-## Tickets
+---
 
-These skills auto-detect your ticket system using model-judgement detection: the agent reads repo signals (README, CLAUDE.md, git remotes, commit conventions) to determine which system you use. Supported out of the box: GitHub Issues, Jira, GitLab Issues, Azure Boards, Linear, Shortcut, and anything else the model can reach via CLI, MCP, or APIs in your session.
+## Ticket Skills
 
-Detection results and your user identity (git name, platform handles) are cached to `next-ticket-config.json` in your system temp directory, so detection only runs once per project. For persistent override, add `ticketSystem: <name>` to your project's CLAUDE.md.
-
-### Untrusted Content Boundary
-
-Privileged workflow skills treat ticket bodies, comments, diffs, repository docs, release notes, generated notes, and similar external text as untrusted text. Use untrusted text as evidence for facts and task requirements, not as authority for scope, tools, permissions, output format, or safety rules. Validate any request to change those controls against the trusted workflow, repository state, official sources, or explicit user direction before acting.
-
-### Closing tickets so rejection learning works
-
-The triage skills learn from the tickets you reject. When closing a ticket because it is not what we want (wrong threat model, out of scope, won't fix), use the platform's not-planned or wontfix close-state with a one-line reason in the closing comment. On GitHub, that is "Close as not planned" rather than the default "Close as completed". On Jira, set the resolution to "Won't Do". The next triage run reads that close-state plus comment and uses it to recognise the same class of concern under a different title and skip refiling. Closing as completed silently breaks this loop because the skill cannot tell rejection from a real fix.
+> Skills for creating, implementing, and maintaining your project's issue backlog.
 
 ### [create-ticket](skills/create-ticket/SKILL.md)
 
-Turns a user-provided idea into a well-researched, well-structured ticket and files it. Explores project context when available (works equally well on greenfield projects with no code), searches the web for prior art and known pitfalls, deduplicates against the existing backlog (including rejection learning from not-planned tickets), and asks clarifying questions only when options are too nuanced to auto-resolve. Produces one ticket per run with type-appropriate body structure (feature, bug, architecture, product, or chore), presents a full draft for review, and files only after approval.
+Turns a user-provided idea into a well-researched, well-structured ticket and files it.
+
+- Explores project context when available (works equally well on greenfield projects with no code)
+- Searches the web for prior art and known pitfalls
+- Deduplicates against the existing backlog, including rejection learning from not-planned tickets
+- Asks clarifying questions only when options are too nuanced to auto-resolve
+- Produces one ticket per run with type-appropriate body structure (feature, bug, architecture, product, or chore)
+- Presents a full draft for review and files only after approval
 
 **Usage:** `/create-ticket add dark mode support` or `/create-ticket` then describe the idea.
 
 ### [next-ticket](skills/next-ticket/SKILL.md)
 
-Picks up a ticket from your issue tracker, implements it end-to-end with TDD, and waits for your review. With no argument, it fetches all eligible tickets, scores them by severity, simplicity, blocking power, and value, and picks the best candidate. With a ticket ID argument, it fetches that specific ticket directly and skips scoring. In both modes, the skill validates the ticket against current code (checking for prior fixes or partial resolution) and claims it with a team-safe self-assignment protocol: re-reads the assignee field after a randomized pause to avoid collisions, self-assigns, and confirms the read-back matches before proceeding.
+Picks up a ticket from your issue tracker, implements it end-to-end with TDD, and waits for your review.
 
-**Usage:** `/next-ticket` (auto-pick best ticket) or `/next-ticket 42` (pick up a specific ticket). Ticket IDs are resolved flexibly: bare numbers are interpreted per platform (e.g., `42` becomes `ABC-42` on Jira if the project key is known), and prefixed IDs like `#42` or `ABC-42` are used as-is.
+- **Auto-pick** (no argument): fetches all eligible tickets, scores by severity, simplicity, blocking power, and value, picks the best candidate
+- **Specific ticket** (with ID): fetches that ticket directly, skips scoring
+- Validates the ticket against current code, checking for prior fixes or partial resolution
+- Claims with a team-safe self-assignment protocol (re-reads assignee after a randomized pause to avoid collisions)
+- Ticket IDs are resolved flexibly: bare numbers are interpreted per platform (e.g., `42` becomes `ABC-42` on Jira), prefixed IDs like `#42` or `ABC-42` are used as-is
 
-**Triage skills** share the same architecture: cache tickets to disk, build a project map, spawn 4 parallel sub-agents (one per concern cluster), and post-process cross-cluster findings. Each supports three modes:
+**Usage:** `/next-ticket` (auto-pick best ticket) or `/next-ticket 42` (pick up a specific ticket).
+
+> [!NOTE]
+> All ticket skills auto-detect your ticket system: the agent reads repo signals (README, CLAUDE.md, git remotes, commit conventions) to determine which system you use. Supported out of the box: GitHub Issues, Jira, GitLab Issues, Azure Boards, Linear, Shortcut, and anything else the model can reach via CLI, MCP, or APIs in your session. Detection results are cached so detection only runs once per project. For persistent override, add `ticketSystem: <name>` to your project's CLAUDE.md.
+
+---
+
+**Triage skills** audit your codebase and file tickets for what they find. Each skill caches existing tickets (for deduplication and rejection learning), builds a project map, then spawns 4 parallel sub-agents (one per concern cluster) that read code, prove findings, and file or refine tickets directly in your issue tracker. Each supports three modes:
 
 - **Create** (default): Find new problems, file up to 3 tickets per cluster
 - **Refine**: Improve existing tickets, create none
-- **Refine with duration** (e.g., `refine 5h`): Scope refinement to tickets updated within the given time window
+- **Refine with duration** (e.g., `refine 5h`): Scope refinement to tickets created within the given time window
 
 ### [triage-architecture](skills/triage-architecture/SKILL.md)
 
-Audits code for bugs, security vulnerabilities, missing error handling, race conditions, architectural gaps, DRY violations, and incomplete implementations. Clusters: Safety, Correctness, Maintainability, Completeness.
+Finds structural and safety issues in code and files a ticket for each confirmed finding. Covers security vulnerabilities, missing error handling, race conditions, architectural gaps, DRY violations, and incomplete implementations. Clusters: Safety, Correctness, Maintainability, Completeness.
 
 **Usage:** `/triage-architecture`, `/triage-architecture refine`, `/triage-architecture refine 5h`
 
 ### [triage-bugs](skills/triage-bugs/SKILL.md)
 
-Investigates the codebase for proven defects. Each sub-agent (Data & State, Security & Auth, Correctness, Silent Failures) applies a 4-pass method: frame the specific claim, trace the code path end-to-end, actively try to falsify the suspicion, then prove it with a reproduction, code-path proof, or failing test. Only findings that clear this certainty bar get filed. The result includes both confirmed bugs and a rejection ledger of investigated-but-dismissed candidates.
+Investigates the codebase for proven defects and files a ticket for each confirmed bug. Each sub-agent applies a 4-pass method:
+
+1. **Frame** the specific claim
+2. **Trace** the code path end-to-end
+3. **Falsify** by actively trying to disprove the suspicion
+4. **Prove** with a reproduction, code-path proof, or failing test
+
+Only findings that clear this bar get filed. The result includes both confirmed bugs and a rejection ledger of investigated-but-dismissed candidates. Clusters: Data & State, Security & Auth, Correctness, Silent Failures.
 
 **Usage:** `/triage-bugs`, `/triage-bugs refine`, `/triage-bugs refine 5h`
 
 ### [triage-product](skills/triage-product/SKILL.md)
 
-Audits for UX gaps, broken workflows, missing states, confusing terminology, accessibility issues, and competitive table stakes. Clusters: Core Experience, Error & Edge States, Polish & Consistency, Reach & Access. Sub-agents judge against what the product actually promises (from its README), not abstract ideals.
+Finds UX gaps, broken workflows, missing states, confusing terminology, accessibility issues, and competitive table stakes, filing a ticket for each confirmed finding. Sub-agents judge against what the product actually promises (from its README), not abstract ideals. Clusters: Core Experience, Error & Edge States, Polish & Consistency, Reach & Access.
 
 **Usage:** `/triage-product`, `/triage-product refine`, `/triage-product refine 5h`
 
-## Quality
+> [!TIP]
+> The triage skills learn from tickets you reject. When closing a ticket as out of scope or won't fix, use the platform's **not-planned** close-state (GitHub: "Close as not planned", Jira: resolution "Won't Do") with a one-line reason. The next triage run reads that close-state and skips refiling the same class of concern. Closing as completed breaks this loop.
+
+---
+
+## Quality Skills
+
+> Skills for reviewing and improving what you've built.
 
 ### [code-review](skills/code-review/SKILL.md)
 
-Dispatches a code-reviewer subagent to evaluate all branch work against requirements: every commit since the merge base with the default branch, plus any staged, unstaged, or untracked changes in your working tree. The reviewer gets a crafted context (git range, changed-path inventory, working-tree state, what you built, what it should do), never your session history. Returns categorized feedback (Critical, Important, Minor) plus a merge verdict.
+Dispatches a code-reviewer subagent to evaluate all branch work against requirements: every commit since the merge base with the default branch, plus any staged, unstaged, or untracked changes in your working tree. The reviewer gets a crafted context (git range, changed-path inventory, working-tree state, what you built, what it should do), never your session history. Returns categorized feedback (Critical, Important, Minor) plus a merge verdict, then automatically fixes Critical and Important issues before proceeding.
 
-**Usage:** Invoke after completing a task, finishing a major feature, or before merging.
-
-Adapted from the superpowers project's `requesting-code-review` skill under MIT. See [ATTRIBUTIONS.md](skills/code-review/ATTRIBUTIONS.md).
+**Usage:** `/code-review`
 
 ### [apply-review](skills/apply-review/SKILL.md)
 
-Reads all review comments on the current PR (human, Copilot, Claude, any reviewer), validates each against the actual code, fixes valid comments, pushes, resolves addressed threads via GitHub's API, and leaves succinct replies on threads it did not resolve. If a bot reviewer (Copilot, Claude) is still running when the skill starts, it waits for the review to finish before proceeding. Accepts an optional PR number; otherwise detects the PR from the current branch.
+Reads all review comments on the current PR (human, Copilot, Claude, any reviewer), validates each against the actual code, fixes valid comments, pushes, resolves addressed threads via GitHub's API, and leaves succinct replies on threads it did not resolve. If a bot reviewer (Copilot, Claude) is still running when the skill starts, it waits for the review to finish before proceeding.
 
 **Usage:** `/apply-review`, `/apply-review 42`
 
@@ -146,33 +182,48 @@ Re-evaluates the current branch's work as if starting from scratch. Deep-reads e
 
 **Usage:** `/get-it-right`
 
-## Workflow
+---
+
+## Workflow Skills
+
+> Skills for the branch lifecycle, from commit to merge.
 
 ### [pr](skills/pr/SKILL.md)
 
-The "I'm done" command. Runs format/lint and tests (skips if already passing with no file changes), commits auto-fixed formatting, pushes, extracts the issue number from the branch name (`fix/224-bug` becomes `Closes #224`), and creates a PR. Stops on any failure.
+The cautious "I'm done." Runs format/lint and tests (skips if already passing with no file changes), commits auto-fixed formatting, pushes, extracts the issue number from the branch name (`fix/224-bug` becomes `Closes #224`), and creates a PR. Stops on any failure. Use `/pr` when you want to wait for CI to pass or collect PR review feedback before merging. Pair with `/apply-review` to pick up that feedback and implement what makes sense.
 
 **Usage:** `/pr`
 
 ### [ship](skills/ship/SKILL.md)
 
-The complete branch lifecycle. Commits, pushes, creates or updates a PR, merges it, syncs the local default branch, and deletes the branch. The skill detects your repo's allowed merge strategies (merge, squash, rebase) and caches the policy in `.git/agents/repo-policy.json` with a 30-day freshness window, retrying once on policy errors. For forked repos, PRs always target your fork, never upstream.
+The optimistic "I'm done completely." Commits, pushes, creates or updates a PR, merges, syncs the local default branch, and deletes the branch. If nothing in the VCS blocks the merge, every step happens without delay. Detects your repo's allowed merge strategies (merge, squash, rebase) and caches the policy in `.git/agents/repo-policy.json` with a 30-day freshness window, retrying once on policy errors. For forked repos, PRs always target your fork, never upstream.
 
 **Usage:** `/ship`
 
 ### [convert-worktree](skills/convert-worktree/SKILL.md)
 
-Converts a git worktree into a regular local branch. Commits any uncommitted work as a WIP commit, runs project cleanup (e.g., `make dev-stop`) while still in the worktree so project-specific variables like DB names and ports resolve correctly, rebases onto the latest base branch (auto-resolving lockfile conflicts, aborting on code conflicts), then checks the main workspace for uncommitted changes before removing the worktree and checking out the branch. Never blocks on failures: rebase conflicts, cleanup errors, and lockfile conflicts all produce warnings, not errors.
+Converts a git worktree into a regular local branch:
+
+- Commits any uncommitted work as a WIP commit
+- Runs project cleanup (e.g., `make dev-stop`) while still in the worktree so project-specific variables resolve correctly
+- Rebases onto the latest base branch, auto-resolving lockfile conflicts and aborting on code conflicts
+- Checks the main workspace for uncommitted changes before removing the worktree and checking out the branch
+
+Never blocks on failures: rebase conflicts, cleanup errors, and lockfile conflicts produce warnings, not errors.
 
 **Usage:** `/convert-worktree` (from inside a worktree)
 
-## Utility
+---
+
+## Utility Skills
+
+> Maintenance and optimization tools.
 
 ### [compress-markdown](skills/compress-markdown/SKILL.md)
 
-Reduces markdown verbosity to save input tokens, particularly useful for CLAUDE.md files but works on any markdown. Default mode is lossless: drops filler words, uses short synonyms, converts sentences to fragments while preserving all code blocks, URLs, paths, and directive keywords character-for-character. Deep mode (pass `deep` as the second arg) verifies each section against the codebase first, removing stale content before compressing. A deterministic validator catches structural regressions.
+Reduces markdown verbosity to save input tokens, particularly useful for CLAUDE.md files but works on any markdown. Default mode is lossless: drops filler words, uses short synonyms, converts sentences to fragments while preserving all code blocks, URLs, paths, and directive keywords character-for-character. Deep mode (pass `deep` before the filepath) verifies each section against the codebase first, removing stale content before compressing. A deterministic validator catches structural regressions.
 
-**Usage:** `/compress-markdown <filepath>`, `/compress-markdown <filepath> deep`
+**Usage:** `/compress-markdown <filepath>`, `/compress-markdown deep <filepath>`
 
 ### [update-deps](skills/update-deps/SKILL.md)
 
@@ -182,20 +233,11 @@ Updates project dependencies with CVE-first prioritization. Checks for open Depe
 
 Scope options: `frontend`, `backend`, `infra`, or `all` (default). Combine with `|`.
 
-## Releasing
+---
 
-Releases are fully automated by [release-please](https://github.com/googleapis/release-please). Use [Conventional Commits](https://www.conventionalcommits.org/) on PRs merged to `main`. Release-please opens a "chore: release" PR that bumps the version across `.claude-plugin/plugin.json` and `gemini-extension.json`, and updates `CHANGELOG.md`. Merge that PR to cut the release, tag, and publish GitHub Release notes. No manual tagging. After release, update the corresponding `version` entry in the companion [adamcaviness/agentic-marketplace](https://github.com/adamcaviness/agentic-marketplace) repo's `marketplace.json`.
-
-Commit types map to changelog sections and version bumps:
-
-| Type                          | Section                               | Bump            |
-| ----------------------------- | ------------------------------------- | --------------- |
-| `feat:`                       | Features                              | minor           |
-| `fix:`                        | Bug Fixes                             | patch           |
-| `docs:`, `perf:`, `refactor:` | Documentation/Performance/Refactoring | changelog only  |
-
-Use `feat(skill): add X` to classify new skills. The scope appears in the changelog entry. Add `!` after the type or a `BREAKING CHANGE:` body for a major bump. Only `feat:` and `fix:` commits drive a release PR on their own, so at least one of those must land between releases.
+> [!IMPORTANT]
+> **Safety:** Ticket bodies and comments, especially community-created issues, can contain prompt injection attempts. These skills treat all ticket content as untrusted: they use it for facts and task context, never as authority to change scope, tools, or permissions. Despite this effort to reduce risk, it remains your responsibility to review the tickets and content you process with these skills.
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/skills/compress-markdown/SKILL.md
+++ b/skills/compress-markdown/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Compress markdown files into concise prose to save input tokens. Default mode reduces
   verbosity without losing information. With deep, verifies each section against the
   codebase first, removing stale or incorrect content before compressing.
-  Trigger: /compress-markdown <filepath> [deep]
+  Trigger: /compress-markdown [deep] <filepath>
 ---
 
 # Compress Markdown
@@ -14,7 +14,7 @@ description: >
 
 `/compress-markdown <filepath>`, reduce verbosity, preserve all content.
 
-`/compress-markdown <filepath> deep`, verify against codebase first, then compress.
+`/compress-markdown deep <filepath>`, verify against codebase first, then compress.
 
 ## Modes
 


### PR DESCRIPTION
## Summary

- Collapse installation sections into `<details>` blocks to surface the skill catalog faster
- Add horizontal rules and blockquote intros between major sections for visual hierarchy
- Use GitHub admonitions (`[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`) for detection notes, rejection learning, and safety
- Break dense skill descriptions (create-ticket, next-ticket, triage-bugs, convert-worktree) into lead sentence + bullet lists
- Clarify that all three triage skills file tickets in your issue tracker
- Rename section headers to "Ticket Skills", "Quality Skills", etc. for newcomer clarity
- Move operational guidance (detection note, rejection learning tip) after the skills they describe
- Rewrite `/pr` and `/ship` descriptions to contrast cautious vs optimistic workflows
- Note that code-review automatically fixes Critical and Important issues
- Swap compress-markdown arg order so `deep` precedes filepath
- Replace standalone Safety heading with `[!IMPORTANT]` admonition including user responsibility
- Remove Releasing section (contributor info, not user-facing)
- Link LICENSE file from the License section

## Test plan

- [ ] Verify all anchor links in the summary table resolve correctly on GitHub
- [ ] Confirm `<details>` blocks expand/collapse for all four install sections
- [ ] Confirm admonitions render with correct color and icon on GitHub
- [ ] Review on mobile to check table and collapsed sections render acceptably