### PR TITLE
feat(skill): non-blocking ticket state transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ When `triage-architecture`, `triage-bugs`, or any other skill audits this repo, 
 
 This boundary is load-bearing for the triage skills' rejection-learning loop: when the operator closes a ticket as not-planned with reasoning grounded in this context, the triage skills cache that reasoning into `issues-closed.json` so future runs can recognize the same class of concern under a different title and skip refiling.
 
-## Mechanical skills
+## User-only skills
 
-Skills whose lifecycle is almost entirely deterministic git, shell, and `gh` orchestration declare `disable-model-invocation: true` in frontmatter so harnesses skip expensive model reasoning for them. Currently honored by Claude Code, tolerated by Codex and Gemini. Apply to `pr`, `ship`, and `convert-worktree`. Add the key to any future skill whose body is a fixed command sequence rather than judgement-driven work.
+Skills that should only be triggered by the user (not autonomously by the model) declare `disable-model-invocation: true` in frontmatter. This prevents the model from invoking the skill on its own initiative; the user must type the slash command explicitly. It does not restrict what the model does during execution. Currently honored by Claude Code, tolerated by Codex and Gemini. Apply to skills with side effects or timing sensitivity where the user controls when they run: `pr`, `ship`, and `convert-worktree`. Add the key to any future skill the user should invoke deliberately rather than the model triggering automatically.
 
 ## Branch lifecycle
 

--- a/skills/next-ticket/SKILL.md
+++ b/skills/next-ticket/SKILL.md
@@ -188,6 +188,40 @@ Before branching or writing code, self-assign the selected ticket in the source 
 4. **Already yours?** Skip the write. Proceed.
 5. **Assignment failed?** If the tool is missing, permissions are denied, or the write errors out, stop with a clear, specific message. Do not start work on a ticket you couldn't claim.
 
+## Step 4.6: Transition to In Progress (non-blocking)
+
+Move the ticket to an active-work state so the board reflects that implementation has started. This entire step is non-blocking: if anything fails, log a one-line note and continue to Step 5.
+
+1. **Check cache.** Read the project-root entry in `next-ticket-config.json`. If it has a `states.in_progress` key, skip to sub-step 4 (Apply).
+2. **Discover available states.** Use whatever CLI, MCP, or API tooling fits the detected ticket system to find the ticket's available statuses, transitions, or board columns. Every ticket system exposes this differently, and teams customize state names extensively, so do not follow a hardcoded recipe. Use model judgment to explore the system's API, CLI, or MCP surface, discover what states exist, and identify which one represents "actively being worked on." Examples of names teams use: "In Progress", "In Development", "Doing", "Active", "Started", "Working", etc., but the real name could be anything.
+3. **Confirm and cache.** On first discovery, confirm with the user: "Transition ticket to '<name>'? This choice will be cached for future runs." Migrate the project-root entry from a plain string to the object form shown below (if not already an object), then write the discovered state under `states.in_progress`. Store whatever system-specific detail (IDs, labels, parameters) the system needs to replay the transition mechanically on future runs without rediscovery.
+4. **Apply the transition** using the cached details and whatever tooling fits the system.
+5. **On any failure** (no project board, no statuses discoverable, API error, permission denied, user declines): log one line (e.g., "Could not transition to in-progress: <reason>") and continue to Step 5 (Create Branch).
+
+When a project-root entry gains `states`, it migrates from a plain string to an object. Both forms are valid; read the string form as `{"system": "<value>"}` with no states yet. The evolved shape:
+
+```json
+{
+  "__user__": {
+    "name": "Adam",
+    "usernames": {
+      "github": "adamcaviness",
+      "jira": "adam.caviness@company.com"
+    }
+  },
+  "/home/user/repo-a": {
+    "system": "github",
+    "states": {
+      "in_progress": { "...system-specific IDs and parameters..." },
+      "in_review": { "...system-specific IDs and parameters..." }
+    }
+  },
+  "/home/user/repo-b": "jira"
+}
+```
+
+The `states` values are opaque to other skills. Each entry stores whatever the ticket system needs (field IDs, transition IDs, option IDs, label names) so future runs can replay the transition without rediscovery. A project-root entry without `states` (plain string or object without the key) simply means no state transitions have been discovered yet.
+
 ## Step 5: Create Branch
 
 This is a hard gate. Do not write tests, edit files, or implement anything until branch creation succeeds and the current branch is verified.
@@ -321,6 +355,7 @@ The UI testing tip must be **specific and actionable**, not "test the feature" b
 - **Never pick a ticket assigned to someone else.** Unassigned and already-yours are both eligible; anything with another person on it is off-limits. In direct-pick mode, the user's explicit selection overrides this: warn that the ticket is assigned to someone else and ask for confirmation before proceeding.
 - **Never pick a ticket with unmet dependencies.** It can't be completed. In direct-pick mode, the user's explicit selection overrides this: warn about unmet dependencies and ask for confirmation before proceeding.
 - **Claim after validating, before branching.** Step 4.5 is the only claim point. Re-read the assignee at the top of it so the race window stays small, and don't claim during a Step 4 refine-and-skip pass.
+- **State transitions are non-blocking.** Step 4.6 transitions the ticket to an active state on the board. If the transition fails for any reason, the workflow continues. Never block implementation on a failed board update.
 - **No identity, no run.** If the per-system handle can't be resolved and the user won't supply one, stop. Running unfiltered on a shared repo recreates the collision this skill is meant to prevent.
 - **Validation (Step 4): refine, don't close.** If a ticket has remaining work and you choose to skip it (auto-pick only), edit the ticket to reflect only what remains (update title and body), then move to the next candidate. In direct-pick mode, always work on remaining items. Never close a ticket that isn't 100% resolved.
 - **Implementation (Steps 5-9): fully implement.** Once you pick a ticket, complete it entirely. No partial commits, no WIP commits, no handoffs. In auto-pick mode, the scoring in Step 3 filters for simplicity and clarity so that picked tickets can be fully implemented touch-free. In direct-pick mode, the user accepted this responsibility by choosing the ticket.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -108,6 +108,15 @@ Single command to go from "I'm done" to "PR is open."
      - Create PR with `gh pr create` passing the title and built body
    - Return PR URL to user
 
+10. **Transition ticket to In Review (non-blocking)**:
+    - Extract a ticket identifier from the branch name. The branch follows `<category>/<ticket-id>-<desc>`, where the ticket ID may be a bare number (`42`) or a prefixed key (`PROJ-42`). If no ticket ID is extractable, skip.
+    - Read `next-ticket-config.json` from the system temp directory. If the file does not exist or has no ticket-system entry for the current project root, skip.
+    - Reconstruct the full ticket identifier for the detected system if needed (e.g., for Jira, if only a bare number was extracted, prepend the project key from the config or repo signals).
+    - Read the project-root entry from the config. If it is a plain string (no `states` key yet) or has no `states.in_review` entry, discover the state. If it has a cached `states.in_review` entry, skip to applying.
+      - **Discover (first run only)**: Use whatever CLI, MCP, or API tooling fits the detected ticket system to discover what states or transitions exist. Every system exposes this differently, and teams customize state names extensively, so do not follow a hardcoded recipe. Use model judgment to identify which option represents "awaiting review" (teams call this anything: "In Review", "Review & Test", "Code Review", "QA", etc.). Confirm with the user: "Transition ticket to '<name>'? This choice will be cached for future runs." Migrate the project-root entry from a plain string to the object form (see `next-ticket` Step 4.6 for the schema) if needed, then write the result under `states.in_review`. Store enough system-specific detail to replay mechanically on future runs.
+      - **Apply**: Transition the ticket using the cached system-specific details.
+    - On any failure (no config file, no ticket system, no transitions available, API error, permission denied, user declines): log a one-line note and continue. This step never blocks the PR workflow.
+
 ## Error Handling
 
 - **On default branch**: Stop immediately, suggest creating feature branch
@@ -119,6 +128,7 @@ Single command to go from "I'm done" to "PR is open."
 - **Push rejected (behind remote)**: Suggest `git pull --rebase origin <branch>`
 - **`gh` not authenticated**: Detect with `gh auth status`, show clear error
 - **No issue number in branch**: Warn but continue. Don't block the PR.
+- **Ticket state transition fails**: Log the reason and continue. Never block the PR workflow.
 
 ## Usage
 

--- a/tests/test_mechanical_skill_execution_profile.py
+++ b/tests/test_mechanical_skill_execution_profile.py
@@ -8,12 +8,12 @@ SKILLS_DIR = REPO_ROOT / "skills"
 AGENTS = REPO_ROOT / "AGENTS.md"
 
 
-MECHANICAL_SKILLS = ["pr", "ship", "convert-worktree"]
+USER_ONLY_SKILLS = ["pr", "ship", "convert-worktree"]
 
 FRONTMATTER_KEY = "disable-model-invocation: true"
 
 AGENTS_REQUIRED_PHRASES = [
-    "mechanical",
+    "user-only skills",
     "disable-model-invocation: true",
 ]
 
@@ -26,26 +26,26 @@ def read_frontmatter(skill_name):
     return match.group(1)
 
 
-class MechanicalSkillExecutionProfileTest(unittest.TestCase):
-    def test_mechanical_skills_disable_model_invocation(self):
-        for skill_name in MECHANICAL_SKILLS:
+class UserOnlySkillTest(unittest.TestCase):
+    def test_user_only_skills_disable_model_invocation(self):
+        for skill_name in USER_ONLY_SKILLS:
             with self.subTest(skill=skill_name):
                 frontmatter = read_frontmatter(skill_name)
                 self.assertIn(
                     FRONTMATTER_KEY,
                     frontmatter,
                     f"{skill_name}: frontmatter must declare {FRONTMATTER_KEY!r} "
-                    "so harnesses skip model invocation for mechanical workflows",
+                    "so the model cannot invoke it autonomously",
                 )
 
-    def test_agents_md_documents_mechanical_execution_rule(self):
+    def test_agents_md_documents_user_only_skill_rule(self):
         text = AGENTS.read_text().lower()
         for phrase in AGENTS_REQUIRED_PHRASES:
             with self.subTest(phrase=phrase):
                 self.assertIn(
                     phrase.lower(),
                     text,
-                    f"AGENTS.md must document the mechanical-execution rule (missing {phrase!r})",
+                    f"AGENTS.md must document the user-only skill rule (missing {phrase!r})",
                 )
 
 


### PR DESCRIPTION
## Summary

- Adds Step 4.6 to `next-ticket` that transitions tickets to an active state (e.g., "In Progress") after claiming, before branching
- Adds Step 10 to `pr` that transitions tickets to a review state (e.g., "In Review") after PR creation, only when ticket system config exists
- Both use model-judgment discovery with user confirmation on first run, cache per-project in `next-ticket-config.json`, and degrade silently on any failure
- Corrects AGENTS.md description of `disable-model-invocation` to match official Anthropic docs: controls who can invoke (user only), not how the skill executes
- Renames "Mechanical skills" section to "User-only skills" and updates the corresponding test

## Changes

- `skills/next-ticket/SKILL.md`: New Step 4.6 with config schema evolution example (plain string to object with `states` key), non-blocking rule in Rules section
- `skills/pr/SKILL.md`: New Step 10 with discover/confirm/cache pattern, error handling entry
- `AGENTS.md`: Section rename and rewritten description
- `tests/test_mechanical_skill_execution_profile.py`: Renamed class, methods, and assertions to match

## Testing

- All 65 tests pass
- Two code review passes, all Critical/Important issues resolved