### PR TITLE
ci(release-please): upgrade action to v5 for the node24 runtime

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps `googleapis/release-please-action` from `v4` (node20 runtime, deprecated by GitHub Actions) to `v5`. v5.0.0's only breaking change is the node24 upgrade; the inputs this workflow uses (token, config-file, manifest-file) and the prs_created/pr outputs are unchanged, so it is a drop-in bump. ci: type, so no release is triggered.