### PR TITLE
docs: clarify Cursor install paths and dual-harness reuse

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -27,6 +27,8 @@ Enable these skills in Codex via native skill discovery. Clone the repo once, th
 
 3. **Restart Codex** (quit and relaunch the CLI) to discover the skills.
 
+> **Also use Cursor?** Cursor can load skills from `~/.agents/skills/` when third-party includes are on. Prefer installing via Claude Code's marketplace for dual Claude Code + Cursor setups (see [.cursor/INSTALL.md](../.cursor/INSTALL.md)), and avoid stacking a Cursor `~/.cursor/plugins/local` install on top of this Codex link for the same skills.
+
 ## Verify
 
 ```bash

--- a/.cursor/INSTALL.md
+++ b/.cursor/INSTALL.md
@@ -2,6 +2,8 @@
 
 User-level install for Cursor desktop and CLI (Pro, Hobby, and other non-Teams plans). Skills are available in every project after one reload.
 
+Use **one** install path only. Cursor also discovers `~/.agents/skills/` and `~/.cursor/skills/`, so linking the same skills there *and* under `~/.cursor/plugins/local/` lists every skill twice.
+
 ## Install (copy-paste)
 
 Requires Git. Paste into Terminal:
@@ -29,6 +31,13 @@ Reload the window again.
 rm -rf ~/.cursor/plugins/local/agentic-toolkit
 ```
 
+If you previously linked this plugin for Codex or manually, also remove duplicates:
+
+```bash
+rm -f ~/.agents/skills/agentic-toolkit
+rm -f ~/.cursor/skills/agentic-toolkit
+```
+
 Reload the window.
 
 ## Already have a clone?
@@ -39,6 +48,8 @@ If you keep a working copy elsewhere (for example this repo), link it instead of
 mkdir -p ~/.cursor/plugins/local
 ln -sfn /absolute/path/to/agentic-toolkit ~/.cursor/plugins/local/agentic-toolkit
 ```
+
+Do **not** also symlink `skills/` into `~/.agents/skills/` or `~/.cursor/skills/` while this plugin link exists.
 
 ## Teams / Enterprise
 

--- a/.cursor/INSTALL.md
+++ b/.cursor/INSTALL.md
@@ -1,56 +1,72 @@
 # Installing Agentic Toolkit for Cursor
 
-User-level install for Cursor desktop and CLI (Pro, Hobby, and other non-Teams plans). Skills are available in every project after one reload.
+Cursor discovers skills from several places. Use **exactly one** of the paths below for this plugin, or every skill appears twice in **Customize → Skills** and under `/` in Agents.
 
-Use **one** install path only. Cursor also discovers `~/.agents/skills/` and `~/.cursor/skills/`, so linking the same skills there *and* under `~/.cursor/plugins/local/` lists every skill twice.
+| Your setup | What to do |
+|---|---|
+| You already use **Claude Code** with this plugin | Install once in Claude Code (path 1). Cursor picks it up automatically. Do **not** also install path 2. |
+| **Cursor only** (Pro / Hobby / individual) | Clone or link into `~/.cursor/plugins/local` (path 2). |
+| **Cursor Teams / Enterprise** admin | Import the marketplace from the web dashboard (path 3). Teammates install from **Customize**. |
 
-## Install (copy-paste)
+Leave **Settings → Rules, Skills, Subagents → Include third-party Plugins, Skills, and other configs** enabled (the default) if you rely on path 1. Turning it off hides Claude Code / Codex skill roots from Cursor.
 
-Requires Git. Paste into Terminal:
+## 1. Via Claude Code (best if you use both)
+
+In Claude Code:
+
+```bash
+/plugin marketplace add adamcaviness/agentic-marketplace
+/plugin install agentic-toolkit@agentic-marketplace
+```
+
+Reload Cursor (**Developer: Reload Window**). Skills show under `/` in Agents and in **Customize → Skills**.
+
+Stop here. Do not also clone or symlink into `~/.cursor/plugins/local`, `~/.cursor/skills/`, or `~/.agents/skills/`.
+
+## 2. Cursor only (Pro / individual, no Claude Code install)
+
+Requires Git. User-level (every project):
 
 ```bash
 mkdir -p ~/.cursor/plugins/local
 git clone https://github.com/adamcaviness/agentic-toolkit.git ~/.cursor/plugins/local/agentic-toolkit
 ```
 
-Then in Cursor: Command Palette → **Developer: Reload Window** (or quit and reopen Cursor).
-
-Confirm in **Customize → Skills**, or type `/` in Agents (for example `/pr`, `/triage-bugs`).
-
-## Update
-
-```bash
-git -C ~/.cursor/plugins/local/agentic-toolkit pull
-```
-
-Reload the window again.
-
-## Uninstall
-
-```bash
-rm -rf ~/.cursor/plugins/local/agentic-toolkit
-```
-
-If you previously linked this plugin for Codex or manually, also remove duplicates:
-
-```bash
-rm -f ~/.agents/skills/agentic-toolkit
-rm -f ~/.cursor/skills/agentic-toolkit
-```
-
-Reload the window.
-
-## Already have a clone?
-
-If you keep a working copy elsewhere (for example this repo), link it instead of cloning twice:
+Or, if you already have a clone on disk:
 
 ```bash
 mkdir -p ~/.cursor/plugins/local
 ln -sfn /absolute/path/to/agentic-toolkit ~/.cursor/plugins/local/agentic-toolkit
 ```
 
-Do **not** also symlink `skills/` into `~/.agents/skills/` or `~/.cursor/skills/` while this plugin link exists.
+Reload the window. Confirm in **Customize → Skills**.
 
-## Teams / Enterprise
+Update a clone install with `git -C ~/.cursor/plugins/local/agentic-toolkit pull`, then reload.
 
-Team Marketplace import is a web admin flow at [cursor.com/dashboard](https://cursor.com/dashboard) → **Plugins**, not a screen in the desktop app. Individuals on Pro should use the install block above.
+Uninstall:
+
+```bash
+rm -rf ~/.cursor/plugins/local/agentic-toolkit
+# only if you also linked elsewhere (usually you should not):
+rm -f ~/.agents/skills/agentic-toolkit
+```
+
+## 3. Cursor Teams / Enterprise
+
+**Dashboard** means the web admin UI at [cursor.com/dashboard](https://cursor.com/dashboard), not a screen inside the Mac app.
+
+1. Admin: **Dashboard → Plugins → Team Marketplaces** → import `https://github.com/adamcaviness/agentic-marketplace`.
+2. Teammates: install **agentic-toolkit** from **Customize** in the Cursor sidebar.
+
+Individuals on Pro should use path 1 or 2 instead.
+
+## Why skills show up twice
+
+Cursor scans, among other roots:
+
+- `~/.cursor/plugins/local/` (Cursor local plugins)
+- `~/.claude/plugins/` (Claude Code marketplace installs), when third-party includes are on
+- `~/.agents/skills/` and `~/.cursor/skills/`
+- `~/.codex/skills/` (Codex), when third-party includes are on
+
+Installing the same skills in more than one of those places duplicates every slash command. Fix: keep a single root, remove the extras, reload.

--- a/.cursor/INSTALL.md
+++ b/.cursor/INSTALL.md
@@ -1,0 +1,45 @@
+# Installing Agentic Toolkit for Cursor
+
+User-level install for Cursor desktop and CLI (Pro, Hobby, and other non-Teams plans). Skills are available in every project after one reload.
+
+## Install (copy-paste)
+
+Requires Git. Paste into Terminal:
+
+```bash
+mkdir -p ~/.cursor/plugins/local
+git clone https://github.com/adamcaviness/agentic-toolkit.git ~/.cursor/plugins/local/agentic-toolkit
+```
+
+Then in Cursor: Command Palette → **Developer: Reload Window** (or quit and reopen Cursor).
+
+Confirm in **Customize → Skills**, or type `/` in Agents (for example `/pr`, `/triage-bugs`).
+
+## Update
+
+```bash
+git -C ~/.cursor/plugins/local/agentic-toolkit pull
+```
+
+Reload the window again.
+
+## Uninstall
+
+```bash
+rm -rf ~/.cursor/plugins/local/agentic-toolkit
+```
+
+Reload the window.
+
+## Already have a clone?
+
+If you keep a working copy elsewhere (for example this repo), link it instead of cloning twice:
+
+```bash
+mkdir -p ~/.cursor/plugins/local
+ln -sfn /absolute/path/to/agentic-toolkit ~/.cursor/plugins/local/agentic-toolkit
+```
+
+## Teams / Enterprise
+
+Team Marketplace import is a web admin flow at [cursor.com/dashboard](https://cursor.com/dashboard) → **Plugins**, not a screen in the desktop app. Individuals on Pro should use the install block above.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Reload the window (**Developer: Reload Window**) or restart Cursor. Skills appea
 
 Update later with `git -C ~/.cursor/plugins/local/agentic-toolkit pull`, then reload again.
 
+Use only this plugin path for Cursor. Do not also symlink into `~/.agents/skills/` or `~/.cursor/skills/`, or every skill appears twice (Cursor discovers all three locations).
+
 > **Teams / Enterprise only:** importing a marketplace repo is a web admin flow at [cursor.com/dashboard](https://cursor.com/dashboard) → **Plugins**, not something in the desktop app. Pro users use the clone path above.
 
 </details>
@@ -83,7 +85,7 @@ Update with `gemini extensions update agentic-toolkit`.
 <details>
 <summary>Manual (any platform)</summary>
 
-If you prefer not to use a plugin/extension system, clone the repo and symlink the skill directories.
+If you prefer not to use a plugin/extension system, clone the repo and symlink the skill directories. Pick **one** discovery location per harness. For Cursor, prefer [.cursor/INSTALL.md](.cursor/INSTALL.md) (`~/.cursor/plugins/local`) instead of the per-skill loops below; using both lists every skill twice.
 
 ```bash
 git clone https://github.com/adamcaviness/agentic-toolkit.git ~/opensource/agentic-toolkit
@@ -94,12 +96,7 @@ for skill in ~/opensource/agentic-toolkit/skills/*/; do
   ln -s "$skill" ~/.claude/skills/"$(basename "$skill")"
 done
 
-# Cursor (user-level)
-for skill in ~/opensource/agentic-toolkit/skills/*/; do
-  ln -s "$skill" ~/.cursor/skills/"$(basename "$skill")"
-done
-
-# Codex (user-level); Cursor also discovers ~/.agents/skills/
+# Codex (user-level)
 for skill in ~/opensource/agentic-toolkit/skills/*/; do
   ln -s "$skill" ~/.agents/skills/"$(basename "$skill")"
 done
@@ -107,7 +104,7 @@ done
 
 For a single skill: `ln -s ~/opensource/agentic-toolkit/skills/next-ticket ~/.claude/skills/next-ticket`.
 
-For project-level install, symlink into `.claude/skills/`, `.cursor/skills/`, or `.agents/skills/` inside the project root.
+For project-level install, symlink into `.claude/skills/` or `.agents/skills/` inside the project root. For Cursor project-level, use `.cursor/skills/` **or** a project-scoped plugin, not both, and not alongside `~/.cursor/plugins/local/agentic-toolkit`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -39,20 +39,13 @@ Register the marketplace, then install the plugin:
 <details>
 <summary>Cursor</summary>
 
-See [.cursor/INSTALL.md](.cursor/INSTALL.md). Short version for Pro (and other individual plans), user-level, every project:
+See [.cursor/INSTALL.md](.cursor/INSTALL.md) for the full matrix. Short version:
 
-```bash
-mkdir -p ~/.cursor/plugins/local
-git clone https://github.com/adamcaviness/agentic-toolkit.git ~/.cursor/plugins/local/agentic-toolkit
-```
+- **Also use Claude Code?** Install once with `/plugin marketplace add adamcaviness/agentic-marketplace` then `/plugin install agentic-toolkit@agentic-marketplace`. Cursor picks it up automatically. Do not also install a Cursor local plugin.
+- **Cursor only (Pro)?** `git clone` into `~/.cursor/plugins/local/agentic-toolkit`, then **Developer: Reload Window**.
+- **Teams / Enterprise?** Admins import the marketplace at [cursor.com/dashboard](https://cursor.com/dashboard) → **Plugins** (web admin UI, not the desktop app).
 
-Reload the window (**Developer: Reload Window**) or restart Cursor. Skills appear under `/` in Agents. Confirm in **Customize → Skills**.
-
-Update later with `git -C ~/.cursor/plugins/local/agentic-toolkit pull`, then reload again.
-
-Use only this plugin path for Cursor. Do not also symlink into `~/.agents/skills/` or `~/.cursor/skills/`, or every skill appears twice (Cursor discovers all three locations).
-
-> **Teams / Enterprise only:** importing a marketplace repo is a web admin flow at [cursor.com/dashboard](https://cursor.com/dashboard) → **Plugins**, not something in the desktop app. Pro users use the clone path above.
+Use exactly one path, or every skill appears twice.
 
 </details>
 
@@ -85,7 +78,7 @@ Update with `gemini extensions update agentic-toolkit`.
 <details>
 <summary>Manual (any platform)</summary>
 
-If you prefer not to use a plugin/extension system, clone the repo and symlink the skill directories. Pick **one** discovery location per harness. For Cursor, prefer [.cursor/INSTALL.md](.cursor/INSTALL.md) (`~/.cursor/plugins/local`) instead of the per-skill loops below; using both lists every skill twice.
+If you prefer not to use a plugin/extension system, clone the repo and symlink the skill directories. Pick **one** discovery location per harness. For Cursor, prefer [.cursor/INSTALL.md](.cursor/INSTALL.md) (Claude Code marketplace reuse, or `~/.cursor/plugins/local`) instead of stacking multiple roots.
 
 ```bash
 git clone https://github.com/adamcaviness/agentic-toolkit.git ~/opensource/agentic-toolkit
@@ -104,7 +97,7 @@ done
 
 For a single skill: `ln -s ~/opensource/agentic-toolkit/skills/next-ticket ~/.claude/skills/next-ticket`.
 
-For project-level install, symlink into `.claude/skills/` or `.agents/skills/` inside the project root. For Cursor project-level, use `.cursor/skills/` **or** a project-scoped plugin, not both, and not alongside `~/.cursor/plugins/local/agentic-toolkit`.
+For project-level install, symlink into `.claude/skills/` or `.agents/skills/` inside the project root. For Cursor, see [.cursor/INSTALL.md](.cursor/INSTALL.md); do not combine a project `.cursor/skills/` tree with a Claude Code marketplace install of the same skills.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -39,17 +39,18 @@ Register the marketplace, then install the plugin:
 <details>
 <summary>Cursor</summary>
 
-For Cursor desktop (and CLI), load the plugin from your local plugins directory:
+See [.cursor/INSTALL.md](.cursor/INSTALL.md). Short version for Pro (and other individual plans), user-level, every project:
 
 ```bash
-git clone https://github.com/adamcaviness/agentic-toolkit.git ~/opensource/agentic-toolkit
 mkdir -p ~/.cursor/plugins/local
-ln -s ~/opensource/agentic-toolkit ~/.cursor/plugins/local/agentic-toolkit
+git clone https://github.com/adamcaviness/agentic-toolkit.git ~/.cursor/plugins/local/agentic-toolkit
 ```
 
-Reload the window (**Developer: Reload Window**) or restart Cursor. Skills appear under `/` in the Agents window (for example `/pr`, `/triage-bugs`). Confirm in **Customize → Skills** in the sidebar.
+Reload the window (**Developer: Reload Window**) or restart Cursor. Skills appear under `/` in Agents. Confirm in **Customize → Skills**.
 
-> **Teams / Enterprise only:** importing a GitHub repo as a Team Marketplace is a web admin flow at [cursor.com/dashboard](https://cursor.com/dashboard) → **Plugins** → **Team Marketplaces**, not something in the desktop app. Admins import `https://github.com/adamcaviness/agentic-marketplace`, then teammates install **agentic-toolkit** from **Customize** in the sidebar. Individual and Hobby plans use the local plugin path above.
+Update later with `git -C ~/.cursor/plugins/local/agentic-toolkit pull`, then reload again.
+
+> **Teams / Enterprise only:** importing a marketplace repo is a web admin flow at [cursor.com/dashboard](https://cursor.com/dashboard) → **Plugins**, not something in the desktop app. Pro users use the clone path above.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ Register the marketplace, then install the plugin:
 <details>
 <summary>Cursor</summary>
 
-Import the marketplace as a Team Marketplace, then install the plugin:
+For Cursor desktop (and CLI), load the plugin from your local plugins directory:
 
-1. Open **Dashboard → Plugins → Team Marketplaces** (or **Customize → Plugins**).
-2. Import `https://github.com/adamcaviness/agentic-marketplace`.
-3. Install **agentic-toolkit** at user or project scope.
+```bash
+git clone https://github.com/adamcaviness/agentic-toolkit.git ~/opensource/agentic-toolkit
+mkdir -p ~/.cursor/plugins/local
+ln -s ~/opensource/agentic-toolkit ~/.cursor/plugins/local/agentic-toolkit
+```
 
-Skills appear under `/` in the Agents window (for example `/pr`, `/triage-bugs`). Open **Customize → Skills** to confirm discovery.
+Reload the window (**Developer: Reload Window**) or restart Cursor. Skills appear under `/` in the Agents window (for example `/pr`, `/triage-bugs`). Confirm in **Customize → Skills** in the sidebar.
+
+> **Teams / Enterprise only:** importing a GitHub repo as a Team Marketplace is a web admin flow at [cursor.com/dashboard](https://cursor.com/dashboard) → **Plugins** → **Team Marketplaces**, not something in the desktop app. Admins import `https://github.com/adamcaviness/agentic-marketplace`, then teammates install **agentic-toolkit** from **Customize** in the sidebar. Individual and Hobby plans use the local plugin path above.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Document all Cursor install options: Claude Code marketplace reuse (recommended if you use both), Cursor-only `~/.cursor/plugins/local`, and Teams web Dashboard import
- Explain that stacking roots duplicates every skill in Customize / Agents
- Point Pro users away from a non-existent in-app Dashboard marketplace import

## Test plan
- [ ] Read `.cursor/INSTALL.md` and README Cursor section for clarity
- [ ] With Claude Code plugin installed only, Cursor shows one copy of each skill after reload
- [ ] Cursor-only clone path still documented for users without Claude Code