### PR TITLE
feat: add a native Codex plugin install path

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "agentic-toolkit",
+  "version": "1.1.0",
+  "description": "A collection of skills for agentic coding tools: next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
+  "author": {
+    "name": "Adam Caviness"
+  },
+  "homepage": "https://github.com/adamcaviness/agentic-toolkit",
+  "repository": "https://github.com/adamcaviness/agentic-toolkit",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "tickets",
+    "planning",
+    "code-review",
+    "workflows",
+    "worktree",
+    "triage",
+    "dependencies",
+    "compression"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Agentic Toolkit",
+    "shortDescription": "Ticket triage, code review, and branch shipping",
+    "longDescription": "Skills for creating and implementing tickets, reviewing code, shipping branches, and triaging bugs, architecture, and product gaps.",
+    "developerName": "Adam Caviness",
+    "category": "Productivity",
+    "websiteURL": "https://github.com/adamcaviness/agentic-toolkit"
+  }
+}

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,54 +1,48 @@
 # Installing Agentic Toolkit for Codex
 
-Enable these skills in Codex via native skill discovery. Clone the repo once, then symlink the `skills/` directory into `~/.agents/skills/`.
+Install from [agentic-marketplace](https://github.com/adamcaviness/agentic-marketplace). Codex loads the plugin (all 13 skills) from `.codex-plugin/plugin.json`. Use **exactly one** path, or skills appear twice.
 
-## Prerequisites
+## 1. ChatGPT desktop (recommended)
 
-- Git
+1. Open **Plugins** → **Add plugin marketplace**.
+2. Source: `adamcaviness/agentic-marketplace` (not `github.com/...`).
+3. Git ref: `main`.
+4. Sparse paths: leave empty.
+5. Add the marketplace, then install **agentic-toolkit**.
+6. Restart ChatGPT / Codex if the plugin does not appear, then start a new chat.
 
-## Installation
-
-1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/adamcaviness/agentic-toolkit.git ~/.codex/agentic-toolkit
-   ```
-
-2. **Create the skills symlink:**
-   ```bash
-   mkdir -p ~/.agents/skills
-   ln -s ~/.codex/agentic-toolkit/skills ~/.agents/skills/agentic-toolkit
-   ```
-
-   **Windows (PowerShell):**
-   ```powershell
-   New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.agents\skills"
-   cmd /c mklink /J "$env:USERPROFILE\.agents\skills\agentic-toolkit" "$env:USERPROFILE\.codex\agentic-toolkit\skills"
-   ```
-
-3. **Restart Codex** (quit and relaunch the CLI) to discover the skills.
-
-> **Also use Cursor?** Cursor can load skills from `~/.agents/skills/` when third-party includes are on. Prefer installing via Claude Code's marketplace for dual Claude Code + Cursor setups (see [.cursor/INSTALL.md](../.cursor/INSTALL.md)), and avoid stacking a Cursor `~/.cursor/plugins/local` install on top of this Codex link for the same skills.
-
-## Verify
-
-```bash
-ls -la ~/.agents/skills/agentic-toolkit
-```
-
-You should see a symlink (or junction on Windows) pointing to the cloned skills directory.
-
-## Updating
-
-```bash
-cd ~/.codex/agentic-toolkit && git pull
-```
-
-Skills update instantly through the symlink.
-
-## Uninstalling
+If you previously cloned this repo and symlinked `skills/` into `~/.agents/skills/agentic-toolkit`, remove that link before installing from the marketplace:
 
 ```bash
 rm ~/.agents/skills/agentic-toolkit
 ```
 
-Optionally delete the clone: `rm -rf ~/.codex/agentic-toolkit`.
+## 2. Codex CLI (optional)
+
+```bash
+codex plugin marketplace add adamcaviness/agentic-marketplace --ref main
+codex plugin add agentic-toolkit@agentic-marketplace
+```
+
+List with `codex plugin list --marketplace agentic-marketplace`. Remove with `codex plugin remove agentic-toolkit@agentic-marketplace`.
+
+## 3. Manual fallback (clone and symlink)
+
+Use this only if you cannot add a marketplace. Do **not** combine it with path 1 or 2.
+
+```bash
+git clone https://github.com/adamcaviness/agentic-toolkit.git ~/.codex/agentic-toolkit
+mkdir -p ~/.agents/skills
+ln -s ~/.codex/agentic-toolkit/skills ~/.agents/skills/agentic-toolkit
+```
+
+**Windows (PowerShell):**
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.agents\skills"
+cmd /c mklink /J "$env:USERPROFILE\.agents\skills\agentic-toolkit" "$env:USERPROFILE\.codex\agentic-toolkit\skills"
+```
+
+Restart Codex. Update with `git -C ~/.codex/agentic-toolkit pull`. Uninstall with `rm ~/.agents/skills/agentic-toolkit`.
+
+> **Also use Cursor?** Cursor can load skills from `~/.agents/skills/` when third-party includes are on. Prefer the Claude Code or Cursor install paths in [.cursor/INSTALL.md](../.cursor/INSTALL.md) for dual Claude Code + Cursor setups, and do not stack a Cursor `~/.cursor/plugins/local` install on top of a Codex symlink for the same skills.

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -2,6 +2,12 @@
 
 Install from [agentic-marketplace](https://github.com/adamcaviness/agentic-marketplace). Codex loads the plugin (all 13 skills) from `.codex-plugin/plugin.json`. Use **exactly one** path, or skills appear twice.
 
+If you previously cloned this repo and symlinked `skills/` into `~/.agents/skills/agentic-toolkit`, remove that link before installing from the marketplace (desktop or CLI):
+
+```bash
+rm ~/.agents/skills/agentic-toolkit
+```
+
 ## 1. ChatGPT desktop (recommended)
 
 1. Open **Plugins** → **Add plugin marketplace**.
@@ -10,12 +16,6 @@ Install from [agentic-marketplace](https://github.com/adamcaviness/agentic-marke
 4. Sparse paths: leave empty.
 5. Add the marketplace, then install **agentic-toolkit**.
 6. Restart ChatGPT / Codex if the plugin does not appear, then start a new chat.
-
-If you previously cloned this repo and symlinked `skills/` into `~/.agents/skills/agentic-toolkit`, remove that link before installing from the marketplace:
-
-```bash
-rm ~/.agents/skills/agentic-toolkit
-```
 
 ## 2. Codex CLI (optional)
 

--- a/README.md
+++ b/README.md
@@ -50,17 +50,20 @@ Use exactly one path, or every skill appears twice.
 </details>
 
 <details>
-<summary>Codex</summary>
+<summary>Codex / ChatGPT desktop</summary>
 
-See [.codex/INSTALL.md](.codex/INSTALL.md). Short version:
+See [.codex/INSTALL.md](.codex/INSTALL.md) for the full matrix. Short version:
+
+In ChatGPT desktop: **Plugins → Add plugin marketplace**. Source `adamcaviness/agentic-marketplace`, Git ref `main`, Sparse paths empty. Then install **agentic-toolkit**.
+
+CLI:
 
 ```bash
-git clone https://github.com/adamcaviness/agentic-toolkit.git ~/.codex/agentic-toolkit
-mkdir -p ~/.agents/skills
-ln -s ~/.codex/agentic-toolkit/skills ~/.agents/skills/agentic-toolkit
+codex plugin marketplace add adamcaviness/agentic-marketplace --ref main
+codex plugin add agentic-toolkit@agentic-marketplace
 ```
 
-Restart Codex to discover the skills.
+Use exactly one path. If you already symlinked `skills/` into `~/.agents/skills/`, remove that link before marketplace-installing.
 
 </details>
 
@@ -78,7 +81,7 @@ Update with `gemini extensions update agentic-toolkit`.
 <details>
 <summary>Manual (any platform)</summary>
 
-If you prefer not to use a plugin/extension system, clone the repo and symlink the skill directories. Pick **one** discovery location per harness. For Cursor, prefer [.cursor/INSTALL.md](.cursor/INSTALL.md) (Claude Code marketplace reuse, or `~/.cursor/plugins/local`) instead of stacking multiple roots.
+If you prefer not to use a plugin/extension system, clone the repo and symlink the skill directories. Pick **one** discovery location per harness. For Cursor, prefer [.cursor/INSTALL.md](.cursor/INSTALL.md) (Claude Code marketplace reuse, or `~/.cursor/plugins/local`) instead of stacking multiple roots. For Codex, prefer [.codex/INSTALL.md](.codex/INSTALL.md) (marketplace install) instead of stacking a `~/.agents/skills/` symlink on top of a plugin install.
 
 ```bash
 git clone https://github.com/adamcaviness/agentic-toolkit.git ~/opensource/agentic-toolkit

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,6 +31,11 @@
         },
         {
           "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "gemini-extension.json",
           "jsonpath": "$.version"
         }

--- a/tests/test_codex_plugin_manifest.py
+++ b/tests/test_codex_plugin_manifest.py
@@ -1,0 +1,65 @@
+"""Codex plugin manifest is a peer of the Claude Code plugin manifest."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAUDE = REPO_ROOT / ".claude-plugin" / "plugin.json"
+CODEX = REPO_ROOT / ".codex-plugin" / "plugin.json"
+
+PEER_KEYS = (
+    "name",
+    "description",
+    "version",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+)
+
+
+class TestCodexPluginManifest(unittest.TestCase):
+    def test_codex_plugin_json_exists(self) -> None:
+        self.assertTrue(CODEX.is_file(), f"missing {CODEX}")
+
+    def test_codex_peers_claude_identity_fields(self) -> None:
+        claude = json.loads(CLAUDE.read_text())
+        codex = json.loads(CODEX.read_text())
+        for key in PEER_KEYS:
+            self.assertIn(key, codex, f"codex missing {key}")
+            self.assertEqual(codex[key], claude[key], f"mismatch on {key}")
+        self.assertEqual(codex["author"]["name"], claude["author"]["name"])
+
+    def test_codex_points_skills_at_repo_skills_dir(self) -> None:
+        codex = json.loads(CODEX.read_text())
+        self.assertEqual(codex["skills"], "./skills/")
+        skill_dirs = [
+            path
+            for path in (REPO_ROOT / "skills").iterdir()
+            if path.is_dir() and (path / "SKILL.md").is_file()
+        ]
+        self.assertGreaterEqual(len(skill_dirs), 1)
+
+    def test_release_please_bumps_codex_plugin_version(self) -> None:
+        config = json.loads(
+            (REPO_ROOT / "release-please-config.json").read_text()
+        )
+        extra = config["packages"]["."]["extra-files"]
+        codex_entries = [
+            e
+            for e in extra
+            if e.get("path") == ".codex-plugin/plugin.json"
+            and e.get("jsonpath") == "$.version"
+        ]
+        self.assertEqual(
+            len(codex_entries),
+            1,
+            "release-please must bump .codex-plugin/plugin.json $.version",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_plugin_manifest.py
+++ b/tests/test_codex_plugin_manifest.py
@@ -41,7 +41,7 @@ class TestCodexPluginManifest(unittest.TestCase):
             for path in (REPO_ROOT / "skills").iterdir()
             if path.is_dir() and (path / "SKILL.md").is_file()
         ]
-        self.assertGreaterEqual(len(skill_dirs), 1)
+        self.assertEqual(len(skill_dirs), 13)
 
     def test_release_please_bumps_codex_plugin_version(self) -> None:
         config = json.loads(


### PR DESCRIPTION
## Summary
- Add `.codex-plugin/plugin.json` as a peer of the Claude and Cursor manifests so Codex / ChatGPT desktop can install this plugin from agentic-marketplace.
- Make marketplace add + install the default Codex path; keep clone-and-symlink as a fallback with a dual-install warning.
- Teach release-please to bump the Codex plugin version, with tests that the identity fields stay in lockstep with Claude.

## Test plan
- [ ] `python -m unittest discover -s tests -p "test_*.py" -t tests -v`
- [ ] Confirm `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` are unchanged
- [ ] After this and the atlas + marketplace PRs merge: in ChatGPT desktop, Add plugin marketplace source `adamcaviness/agentic-marketplace`, Git ref `main`, Sparse paths empty, then install agentic-toolkit
- [ ] Confirm skills load in a new Codex chat without a `~/.agents/skills/` symlink