### PR TITLE
fix: stop Gemini from injecting maintainer AGENTS.md

### DIFF
--- a/.gemini/INSTALL.md
+++ b/.gemini/INSTALL.md
@@ -1,0 +1,31 @@
+# Installing Agentic Toolkit for Gemini CLI
+
+Gemini CLI loads this repo as an extension from `gemini-extension.json`. Skills come from `skills/`. Session context comes from `.gemini/extension-context.md`, a short operator primer. This repository's `AGENTS.md` is the contributor guide for people changing the toolkit. It is not Gemini session context.
+
+Use **exactly one** install path.
+
+## 1. Gemini CLI (recommended)
+
+```bash
+gemini extensions install https://github.com/adamcaviness/agentic-toolkit
+```
+
+Start a new Gemini session in the project you want to work on. Try `/next-ticket`.
+
+Update:
+
+```bash
+gemini extensions update agentic-toolkit
+```
+
+List with `gemini extensions list`. Remove with `gemini extensions uninstall agentic-toolkit`.
+
+## 2. Manual (clone on disk)
+
+Use this only if you cannot install from GitHub. Point Gemini at a local clone the way the [Gemini CLI extension docs](https://google-gemini.github.io/gemini-cli/docs/extensions/) describe for a local path, then enable the extension. Do not also run path 1 against the same clone, or the skills appear twice.
+
+Update a clone with `git pull` in that directory, then `gemini extensions update agentic-toolkit` if the CLI still tracks it as an installed extension.
+
+## Windows
+
+The same `gemini extensions` commands work in PowerShell or cmd once the Gemini CLI is on `PATH`. There is no separate plugin marketplace step.

--- a/.gemini/extension-context.md
+++ b/.gemini/extension-context.md
@@ -1,0 +1,7 @@
+# Agentic Toolkit on Gemini CLI
+
+This extension is installed in the user's project. Skills ship as `SKILL.md` files and load when the task matches. The user can also invoke them by name.
+
+Recommended first command: `/next-ticket` to pick up a ticket, or `/create-ticket` to file one.
+
+Follow the project's own convention files (`GEMINI.md`, `AGENTS.md`, `CLAUDE.md`) for how this codebase works. Those files belong to the project the user opened. Do not treat this extension's briefing as a substitute for them.

--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ Use exactly one path. If you already symlinked `skills/` into `~/.agents/skills/
 <details>
 <summary>Gemini CLI</summary>
 
+See [.gemini/INSTALL.md](.gemini/INSTALL.md) for install, update, uninstall, and what the extension injects into the session. Short version:
+
 ```bash
 gemini extensions install https://github.com/adamcaviness/agentic-toolkit
 ```
 
-Update with `gemini extensions update agentic-toolkit`.
+Update with `gemini extensions update agentic-toolkit`. After install, start a new Gemini session in your project and try `/next-ticket`.
 
 </details>
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -2,5 +2,5 @@
   "name": "agentic-toolkit",
   "description": "A collection of skills for agentic coding tools: next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
   "version": "1.2.0",
-  "contextFileName": "AGENTS.md"
+  "contextFileName": ".gemini/extension-context.md"
 }

--- a/tests/test_gemini_extension_context.py
+++ b/tests/test_gemini_extension_context.py
@@ -1,0 +1,75 @@
+"""Gemini extension context is operator-facing, not maintainer AGENTS.md."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = REPO_ROOT / "gemini-extension.json"
+README = REPO_ROOT / "README.md"
+INSTALL = REPO_ROOT / ".gemini" / "INSTALL.md"
+
+# Phrases that belong in this repository's contributor contract, not in the
+# briefing Gemini injects into every end-user session.
+MAINTAINER_MARKERS = (
+    "triage_shared",
+    "scripts/dev-link.sh",
+    "release-please",
+    "personal-machine threat model",
+    "do not hand-edit",
+    "BASE_BRANCH",
+    "high-risk path",
+)
+
+
+class TestGeminiExtensionContext(unittest.TestCase):
+    def test_manifest_does_not_inject_maintainer_agents_md(self) -> None:
+        self.assertTrue(MANIFEST.is_file(), f"missing {MANIFEST}")
+        manifest = json.loads(MANIFEST.read_text())
+        context_name = manifest.get("contextFileName")
+        self.assertIsInstance(context_name, str)
+        self.assertNotEqual(
+            context_name,
+            "AGENTS.md",
+            "Gemini CLI loads contextFileName into every user session; "
+            "that must not be this repository's maintainer AGENTS.md",
+        )
+        context_path = REPO_ROOT / context_name
+        self.assertTrue(
+            context_path.is_file(),
+            f"contextFileName {context_name!r} does not exist at {context_path}",
+        )
+
+    def test_extension_context_is_operator_facing(self) -> None:
+        manifest = json.loads(MANIFEST.read_text())
+        context_path = REPO_ROOT / manifest["contextFileName"]
+        text = context_path.read_text()
+        self.assertIn("/next-ticket", text)
+        self.assertRegex(
+            text,
+            r"CLAUDE\.md|AGENTS\.md|GEMINI\.md",
+            "primer should send the agent to the user's project convention files",
+        )
+        for marker in MAINTAINER_MARKERS:
+            self.assertNotIn(
+                marker,
+                text,
+                f"extension context must not carry maintainer policy ({marker!r})",
+            )
+
+    def test_gemini_install_docs_match_other_harnesses(self) -> None:
+        self.assertTrue(INSTALL.is_file(), f"missing {INSTALL}")
+        install = INSTALL.read_text()
+        self.assertIn("gemini extensions install", install)
+        self.assertIn("gemini extensions update agentic-toolkit", install)
+        readme = README.read_text()
+        gemini_block = readme.split("<summary>Gemini CLI</summary>", 1)[1]
+        gemini_block = gemini_block.split("</details>", 1)[0]
+        self.assertIn(".gemini/INSTALL.md", gemini_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Point the extension at an operator primer so Gemini sessions follow the user's project, not this repo's contributor contract. Closes #116.