### PR TITLE
fix: name create-ticket on installer marketplace cards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-toolkit",
-  "description": "A collection of skills for agentic coding tools: next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
+  "description": "A collection of skills for agentic coding tools: create-ticket, next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
   "version": "1.2.1",
   "author": {
     "name": "Adam Caviness"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-toolkit",
   "version": "1.2.1",
-  "description": "A collection of skills for agentic coding tools: next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
+  "description": "A collection of skills for agentic coding tools: create-ticket, next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
   "author": {
     "name": "Adam Caviness"
   },
@@ -22,7 +22,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Agentic Toolkit",
-    "shortDescription": "Ticket triage, code review, and branch shipping",
+    "shortDescription": "Ticket creation, triage, code review, and branch shipping",
     "longDescription": "Skills for creating and implementing tickets, reviewing code, shipping branches, and triaging bugs, architecture, and product gaps.",
     "developerName": "Adam Caviness",
     "category": "Productivity",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-toolkit",
-  "description": "A collection of skills for agentic coding tools: next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
+  "description": "A collection of skills for agentic coding tools: create-ticket, next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
   "version": "1.2.1",
   "author": {
     "name": "Adam Caviness"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-toolkit",
-  "description": "A collection of skills for agentic coding tools: next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
+  "description": "A collection of skills for agentic coding tools: create-ticket, next-ticket, get-it-right, code-review, apply-review, pr, ship, convert-worktree, triage-bugs, triage-product, triage-architecture, update-deps, compress-markdown",
   "version": "1.2.1",
   "contextFileName": ".gemini/extension-context.md"
 }

--- a/tests/test_plugin_marketplace_catalog.py
+++ b/tests/test_plugin_marketplace_catalog.py
@@ -1,0 +1,66 @@
+"""Installer cards list the same skill catalog as the repo ships."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAUDE = REPO_ROOT / ".claude-plugin" / "plugin.json"
+CURSOR = REPO_ROOT / ".cursor-plugin" / "plugin.json"
+CODEX = REPO_ROOT / ".codex-plugin" / "plugin.json"
+GEMINI = REPO_ROOT / "gemini-extension.json"
+
+
+def shipped_skill_names() -> set[str]:
+    return {
+        path.name
+        for path in (REPO_ROOT / "skills").iterdir()
+        if path.is_dir() and (path / "SKILL.md").is_file()
+    }
+
+
+def names_in_description(description: str) -> list[str]:
+    _, _, listed = description.partition(":")
+    return [part.strip() for part in listed.split(",") if part.strip()]
+
+
+class TestPluginMarketplaceCatalog(unittest.TestCase):
+    def test_plugin_descriptions_name_every_shipped_skill(self) -> None:
+        expected = shipped_skill_names()
+        self.assertIn("create-ticket", expected)
+        manifests = {
+            ".claude-plugin/plugin.json": json.loads(CLAUDE.read_text()),
+            ".cursor-plugin/plugin.json": json.loads(CURSOR.read_text()),
+            ".codex-plugin/plugin.json": json.loads(CODEX.read_text()),
+            "gemini-extension.json": json.loads(GEMINI.read_text()),
+        }
+        for path, manifest in manifests.items():
+            listed = names_in_description(manifest["description"])
+            self.assertEqual(
+                set(listed),
+                expected,
+                f"{path} description must name every shipped skill, "
+                "including create-ticket",
+            )
+            self.assertEqual(
+                len(listed),
+                len(set(listed)),
+                f"{path} description repeats a skill name",
+            )
+
+    def test_codex_short_description_mentions_creating_tickets(self) -> None:
+        codex = json.loads(CODEX.read_text())
+        short = codex["interface"]["shortDescription"].lower()
+        self.assertRegex(
+            short,
+            r"creat",
+            "Codex marketplace shortDescription must mention creating tickets "
+            "before install, not only triage and shipping",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `create-ticket` to the Claude Code, Cursor, Codex, and Gemini installer descriptions so marketplace cards list all 13 shipped skills.
- Mention ticket creation in Codex's short description so the card matches the README catalog.
- Lock the catalog to `skills/` with a validator so a twelve-name list cannot return unnoticed.

## Test plan
- [ ] Confirm `python -m unittest discover -s tests -p "test_*.py" -t tests` passes, including `test_plugin_marketplace_catalog`.
- [ ] Open each harness installer card and confirm `create-ticket` appears in the skill list.
- [ ] Confirm Codex short description says ticket creation.

Closes #110