### PR TITLE
fix(get-it-right): stop on a dirty tree until leftover is confirmed

### DIFF
--- a/skills/get-it-right/SKILL.md
+++ b/skills/get-it-right/SKILL.md
@@ -33,10 +33,15 @@ if [ -z "$BASE_BRANCH" ]; then
 fi
 ```
 
-Determine what work is being done on the current branch:
+Run `git status --porcelain`. If the working tree has uncommitted changes, list the paths and stop. Do not treat those paths as leftover from an earlier run of this skill, and do not enter Step 2 or auto-implement until the operator responds.
+
+- If the paths are leftover from a previous `/get-it-right` on this branch, the operator says proceed. Include them in the scope below.
+- If they are work from another task, tell the operator to commit, stash, or discard them first. This is the same dirty-tree stop as `apply-review` and `update-deps`. `/get-it-right` only rewrites the branch's intended footprint.
+
+Then determine what work is being done on the current branch:
 - `git log "$BASE_REF"..HEAD --oneline`, all commits on this branch
 - `git diff "$BASE_REF"...HEAD --stat`, all changed files
-- `git status --porcelain`, uncommitted work this skill may have left from an earlier run
+- `git status --porcelain`, uncommitted work the operator confirmed as leftover, or a clean tree
 - If issue number is in branch name, read the GitHub issue for original intent
 
 When all three are empty the branch has no work to re-architect. Stop here and report it, then ask the user which branch or change set to target. Do not enter Step 2 with an empty scope: every later step, the retrospective, the plan, and the footprint guard's percentage, is undefined against a zero-file footprint.
@@ -129,6 +134,8 @@ When the guard holds, print a one-line summary (original count, planned count, n
 
 ### 5. Auto-Implement
 
+Do not start this step while uncommitted paths remain unconfirmed. The Step 1 dirty-tree gate is the stop.
+
 Execute the plan without user interaction:
 - Make all changes across the codebase
 - Run format and lint (check CLAUDE.md for project commands)
@@ -150,5 +157,6 @@ After implementation, output a brief playbook the user follows in the running ap
 - **Fewer abstractions > more abstractions.** Every indirection layer must earn its keep.
 - **Tests are the constraint.** All existing behavior must be preserved. Tests must pass.
 - **Stay within the branch's footprint.** Re-architecture that adds files the branch does not already touch needs the user's confirmation before auto-implementing. The footprint guard in Step 4.5 defines the allowance and the stop point.
+- **Don't rewrite a dirty tree.** Uncommitted paths are not leftover until the operator says so. Stop, list the paths, and wait. Align with `apply-review` / `update-deps` so this skill only rewrites the branch's intended footprint.
 - **Don't commit.** The user reviews everything before any git operations.
-- **Don't ask.** Auto-implement unaided when the footprint guard holds. The testing playbook is how the user validates.
+- **Don't ask.** Auto-implement unaided when the dirty-tree gate and the footprint guard both hold. The testing playbook is how the user validates.

--- a/tests/test_get_it_right_dirty_tree_gate.py
+++ b/tests/test_get_it_right_dirty_tree_gate.py
@@ -1,0 +1,74 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills" / "get-it-right" / "SKILL.md"
+
+
+class GetItRightDirtyTreeGateTest(unittest.TestCase):
+    def setUp(self):
+        self.text = SKILL_PATH.read_text()
+        self.lower = self.text.lower()
+
+    def test_scope_step_checks_porcelain_before_auto_implement(self):
+        scope = self._section("### 1. Identify Scope", "### ")
+        auto_impl_idx = self.text.index("### 5. Auto-Implement")
+        scope_idx = self.text.index("### 1. Identify Scope")
+        self.assertLess(scope_idx, auto_impl_idx)
+        self.assertIn("git status --porcelain", scope)
+
+    def test_dirty_tree_lists_paths_and_stops(self):
+        scope = self._section("### 1. Identify Scope", "### ").lower()
+        self.assertRegex(scope, r"list (the )?paths")
+        self.assertRegex(scope, r"\bstop\b")
+        self.assertRegex(
+            scope,
+            r"do not (enter|auto-implement)|not enter step 2|until the (operator|user) (responds|says)",
+        )
+
+    def test_uncommitted_paths_are_not_assumed_leftover(self):
+        scope = self._section("### 1. Identify Scope", "### ").lower()
+        self.assertRegex(
+            scope,
+            r"do not treat|not leftover|not treat those paths as leftover",
+        )
+        self.assertNotRegex(
+            scope,
+            r"uncommitted work this skill may have left from an earlier run",
+        )
+
+    def test_gate_offers_leftover_proceed_or_unrelated_stop(self):
+        scope = self._section("### 1. Identify Scope", "### ").lower()
+        self.assertIn("leftover", scope)
+        self.assertRegex(scope, r"proceed")
+        self.assertRegex(
+            scope,
+            r"commit.*(stash|discard)|stash.*(commit|discard)|discard.*(commit|stash)",
+        )
+        self.assertRegex(scope, r"apply-review|update-deps")
+
+    def test_key_principles_keep_unconfirmed_dirty_tree_out_of_scope(self):
+        principles = self._section("## Key Principles", None).lower()
+        self.assertRegex(
+            principles,
+            r"dirty tree|uncommitted",
+        )
+        self.assertRegex(
+            principles,
+            r"intended footprint|not in-scope|not leftover until",
+        )
+
+    def _section(self, heading: str, next_heading_prefix: str | None) -> str:
+        start = self.text.index(heading)
+        if next_heading_prefix is None:
+            return self.text[start:]
+        rest = self.text[start + len(heading) :]
+        nxt = rest.find("\n" + next_heading_prefix)
+        if nxt == -1:
+            return self.text[start:]
+        return self.text[start : start + len(heading) + nxt]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `/get-it-right` no longer treats a dirty working tree as leftover from a prior run.
- Uncommitted paths are listed and the skill waits: leftover from this skill may proceed; unrelated work must be committed, stashed, or discarded.
- Auto-implement does not start until that gate holds, so the skill only rewrites the branch's intended footprint.

Closes #123

## Test plan
- [ ] Run `/get-it-right` on a branch with an unrelated untracked file; it should list that path and wait instead of rewriting it
- [ ] Confirm leftover from a previous `/get-it-right` proceeds after you say proceed
- [ ] `python -m unittest discover -s tests -p "test_*.py" -t tests`