### PR TITLE
fix(update-deps): fail loud when CVE-PR discovery cannot run

### DIFF
--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -78,12 +78,14 @@ Using `gh pr list`, fetch open PRs authored by known dependency bots: `dependabo
 ```bash
 set -o pipefail
 (
+  set -e
   gh pr list --author "app/dependabot" --state open --json number,title,author,body
   gh pr list --author "app/renovate" --state open --json number,title,author,body
   gh pr list --author "snyk-bot" --state open --json number,title,author,body
   gh pr list --author "app/greenkeeper" --state open --json number,title,author,body
 ) | jq -s 'add // []'
 ```
+Any failed query must abort the whole discovery block (`set -e` inside the subshell, or `&&` between queries). Do not use bare `;` between `gh pr list` calls: an early failure with a later success would look like a clean (possibly empty) bot list.
 
 If any `gh pr list` returns non-zero, CVE-PR discovery failed: tell the operator, show the error, and stop (or continue only after they confirm skipping the check). A successful run that returns `[]` means there are no bot PRs.
 

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -62,18 +62,30 @@ If no manifests match the requested scope, tell the user and stop.
 
 ## Step 2: Check Open PRs for Automated CVE Patches
 
-Using whatever CLI is available (e.g., `gh pr list`), fetch open PRs authored by known dependency bots: `dependabot`, `renovate`, `snyk-bot`, `greenkeeper`.
-
-**Important**: `gh pr list --author` accepts only a single value. You MUST run a separate query per bot and merge the results. Note that `dependabot`, `renovate`, and `greenkeeper` are GitHub Apps (use the `app/` prefix), while `snyk-bot` is a regular GitHub user account (no prefix).
+CVE-PR discovery uses the GitHub CLI. Verify it before treating an empty bot list as real:
 
 ```bash
+command -v gh >/dev/null || { printf 'gh is not installed. Install the GitHub CLI (https://cli.github.com/) to discover Dependabot/Renovate CVE PRs, or confirm you want to skip this check.\n' >&2; exit 1; }
+gh auth status || { printf 'gh is not authenticated. Run: gh auth login\n' >&2; exit 1; }
+```
+
+If `gh` is missing, unauthenticated, or either check fails, tell the operator that CVE-PR discovery failed and what to install or how to re-auth. Do not continue as if the bot list were empty unless they explicitly confirm skipping that check.
+
+Using `gh pr list`, fetch open PRs authored by known dependency bots: `dependabot`, `renovate`, `snyk-bot`, `greenkeeper`.
+
+**Important**: `gh pr list --author` accepts only a single value. You MUST run a separate query per bot and merge the results. Note that `dependabot`, `renovate`, and `greenkeeper` are GitHub Apps (use the `app/` prefix), while `snyk-bot` is a regular GitHub user account (no prefix). Do not redirect stderr to `/dev/null`; a failing query must surface.
+
+```bash
+set -o pipefail
 (
-  gh pr list --author "app/dependabot" --state open --json number,title,author,body 2>/dev/null
-  gh pr list --author "app/renovate" --state open --json number,title,author,body 2>/dev/null
-  gh pr list --author "snyk-bot" --state open --json number,title,author,body 2>/dev/null
-  gh pr list --author "app/greenkeeper" --state open --json number,title,author,body 2>/dev/null
+  gh pr list --author "app/dependabot" --state open --json number,title,author,body
+  gh pr list --author "app/renovate" --state open --json number,title,author,body
+  gh pr list --author "snyk-bot" --state open --json number,title,author,body
+  gh pr list --author "app/greenkeeper" --state open --json number,title,author,body
 ) | jq -s 'add // []'
 ```
+
+If any `gh pr list` returns non-zero, CVE-PR discovery failed: tell the operator, show the error, and stop (or continue only after they confirm skipping the check). A successful run that returns `[]` means there are no bot PRs.
 
 For each bot PR:
 
@@ -437,6 +449,8 @@ Never push, create PRs, or merge. The user reviews first.
 **No outdated deps**: If discovery finds nothing to update and no bot PRs exist, tell the user and stop. Do not create a branch.
 
 **No bot PRs but outdated deps exist**: Proceed normally. The CVE-required list is empty.
+
+**CVE-PR discovery failed** (`gh` missing, not authenticated, or `gh pr list` non-zero): Tell the operator what failed and how to install or re-auth. Do not treat this as an empty bot list. Continue only if they confirm skipping the check.
 
 **Mixed CVE and major flag**: If a CVE-required dep also appears on the all-majors list, process it once, with CVE noted in the commit message.
 

--- a/tests/test_update_deps_cve_discovery_gate.py
+++ b/tests/test_update_deps_cve_discovery_gate.py
@@ -1,0 +1,74 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills" / "update-deps" / "SKILL.md"
+
+
+class UpdateDepsCveDiscoveryGateTest(unittest.TestCase):
+    """#124: missing/failing gh must not look like an empty bot-PR list."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = SKILL_PATH.read_text()
+        cls.lower = cls.text.lower()
+
+    def _step_2(self):
+        match = re.search(
+            r"(^## Step 2: Check Open PRs for Automated CVE Patches.*?)(?=^## )",
+            self.text,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, "Could not find Step 2 block")
+        return match.group(1)
+
+    def test_step_2_does_not_swallow_gh_stderr_on_bot_queries(self):
+        block = self._step_2()
+        # The fail-open pattern that hid missing/unauthenticated gh.
+        self.assertNotRegex(
+            block,
+            r"gh pr list[^\n]*2>/dev/null",
+            "gh pr list must not redirect stderr to /dev/null",
+        )
+
+    def test_step_2_requires_gh_availability_or_auth_before_empty_bot_list(self):
+        block = self._step_2().lower()
+        self.assertRegex(
+            block,
+            r"gh auth status|command -v gh|not (installed|authenticated)|missing",
+        )
+        # Discovery failure must be named distinctly from "no bot PRs".
+        self.assertRegex(
+            block,
+            r"cve[- ]?pr discovery failed|discovery failed|failed to (discover|list|query)",
+        )
+
+    def test_step_2_empty_bot_list_only_after_successful_discovery(self):
+        block = self._step_2().lower()
+        # The empty-list proceed path must not apply when discovery failed.
+        self.assertRegex(
+            block,
+            r"(confirm|explicitly).*(skip|skipping).*(check|discovery)|"
+            r"do not continue as if.*(empty|no bot)",
+        )
+        self.assertIn("if no bot prs are found, proceed normally", block)
+
+    def test_edge_cases_distinguish_discovery_failure_from_no_bot_prs(self):
+        edge = re.search(
+            r"(^## Edge Cases.*?)(?=^## Rules)",
+            self.text,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(edge, "Could not find Edge Cases block")
+        lower = edge.group(1).lower()
+        self.assertRegex(
+            lower,
+            r"(gh|github cli).*(missing|not authenticated|fail)|"
+            r"discovery fail",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_deps_cve_discovery_gate.py
+++ b/tests/test_update_deps_cve_discovery_gate.py
@@ -33,6 +33,16 @@ class UpdateDepsCveDiscoveryGateTest(unittest.TestCase):
             "gh pr list must not redirect stderr to /dev/null",
         )
 
+    def test_step_2_bot_query_block_aborts_on_any_failed_query(self):
+        block = self._step_2()
+        # pipefail alone is not enough: a subshell of `gh; gh; …` exits with
+        # the last status, so an early failure can still look like success.
+        self.assertRegex(
+            block,
+            r"set -e|gh pr list[^\n]*&&\s*gh pr list",
+            "bot queries must abort on first failure (set -e or &&)",
+        )
+
     def test_step_2_requires_gh_availability_or_auth_before_empty_bot_list(self):
         block = self._step_2().lower()
         self.assertRegex(


### PR DESCRIPTION
## Summary
- Stop treating a missing, unauthenticated, or failing `gh` as an empty Dependabot/Renovate bot-PR list in `/update-deps` Step 2.
- Require explicit confirmation before skipping CVE-PR discovery, and abort the bot-query block on the first failed `gh pr list`.
- Add contract tests so the silent-empty regression cannot return unnoticed.

## Test plan
- [x] `python3 -m unittest discover -s tests` (123 OK)
- [ ] Run `/update-deps` with `gh` unavailable or logged out; confirm it stops and offers skip instead of reporting no bot PRs
- [ ] Run `/update-deps` with working `gh` and no bot PRs; confirm it still proceeds with an empty CVE-required list

Closes #124