### PR TITLE
fix: name the next command at each ticket-to-PR loop seam

### DIFF
--- a/skills/apply-review/SKILL.md
+++ b/skills/apply-review/SKILL.md
@@ -257,6 +257,8 @@ Invalid feedback (<N> threads):
   <file>:<line>  <reason> (@reviewer)
 
 Skipped: <N> already resolved, <N> praise/approval
+
+Once CI is green, run /ship to merge and clean up. Wait for CI before shipping.
 ```
 
 Omit any section with zero entries. The "Invalid feedback" section surfaces which review comments were wrong and why.

--- a/skills/create-ticket/SKILL.md
+++ b/skills/create-ticket/SKILL.md
@@ -309,6 +309,7 @@ Print confirmation:
 Filed: <ticket-id> - "<ticket title>"
 Labels: <type>, <severity>
 URL: <ticket-url>
+To pick it up, run /next-ticket <ticket-id>.
 ```
 
 If the idea was decomposed in Step 1 or Step 6, remind the user:

--- a/skills/get-it-right/SKILL.md
+++ b/skills/get-it-right/SKILL.md
@@ -150,6 +150,8 @@ After implementation, output a brief playbook the user follows in the running ap
 - Be specific: what to do, what to expect
 - Keep it short. 3-6 items max, not an exhaustive checklist.
 
+Do not commit. After the playbook, tell the user: when the checks pass, run `/pr`. Review the unstaged diff first.
+
 ## Key Principles
 
 - **The current implementation is your teacher.** Understand why it was built this way before changing it.

--- a/skills/next-ticket/SKILL.md
+++ b/skills/next-ticket/SKILL.md
@@ -94,7 +94,7 @@ Auto-pick fetches in two phases so the model never pulls full bodies for tickets
 - Azure Boards: `az boards work-item list` with a WIQL filter using `@Me`, `[System.AssignedTo] = ''`, and `[System.State]` restricted to the actionable states.
 - Other: Use whatever is available. If no tool is found, tell the user what to install and stop.
 
-If zero actionable tickets, tell the user and stop.
+If zero actionable tickets, tell the user and stop. Point them at `/create-ticket` to file work.
 
 ### Normalized shape
 
@@ -380,6 +380,8 @@ Top issues:
   ...
 
 To test in the UI: <one sentence describing the specific UI action that exercises this change>
+
+When you are ready to publish, run /pr (opens a PR and stops) or /ship (merges and cleans up). Review locally first.
 ```
 
 If the reviewer found zero issues, replace the two Review lines with `Review: clean | Verdict: Yes`. If review failed or was skipped per Step 9.5's failure mode, replace them with `Review: skipped (<reason>)`. The `Top issues:` block is omitted when there are no captured issues.

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -442,6 +442,8 @@ Bot PRs that should auto-close:
   #92 (dependabot: lodash)
 
 WARNING: 1 CVE update(s) NOT applied. See above.
+
+When you are ready to publish, run /pr (opens a PR and stops) or /ship (merges and cleans up). Review locally first.
 ```
 
 Never push, create PRs, or merge. The user reviews first.

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -415,6 +415,8 @@ The closing headline is conditional on the same list:
 - If the reverted-CVE list is empty, print `All tests passing. Ready for review.`
 - If the reverted-CVE list has one or more entries, print `WARNING: <N> CVE update(s) NOT applied. See above.` instead. Never print the success line when any CVE was reverted.
 
+After whichever headline, always print: `When you are ready to publish, run /pr (opens a PR and stops) or /ship (merges and cleans up). Review locally first.`
+
 Final summary template:
 
 ```

--- a/tests/test_loop_next_command_handoff.py
+++ b/tests/test_loop_next_command_handoff.py
@@ -72,6 +72,20 @@ class LoopNextCommandHandoffTest(unittest.TestCase):
         )
         self.assertIn("Never push, create PRs, or merge.", block)
 
+    def test_update_deps_publish_handoff_follows_either_headline(self):
+        block = step_block(
+            skill_text("update-deps"), "## Step 9: Cleanup and Summary"
+        )
+        bullets = block.split("Final summary template:", 1)[0]
+        self.assertIn("/pr", bullets)
+        self.assertIn("/ship", bullets)
+        self.assertRegex(
+            bullets.lower(),
+            r"after whichever headline|always print",
+            "success-path close must instruct the publish line after either headline, "
+            "not only under the WARNING example in the template",
+        )
+
     def test_get_it_right_playbook_names_pr(self):
         text = skill_text("get-it-right")
         match = re.search(

--- a/tests/test_loop_next_command_handoff.py
+++ b/tests/test_loop_next_command_handoff.py
@@ -1,0 +1,96 @@
+"""Terminal summaries must name the next command in the advertised loop.
+
+Issue #114: /create-ticket, /next-ticket, /pr, /ship, and /apply-review form a
+loop in the README, but the implement and empty-state skills stop without
+naming the follow-on. Keep the never-auto-push rule; add the handoff.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS = REPO_ROOT / "skills"
+
+
+def skill_text(name: str) -> str:
+    return (SKILLS / name / "SKILL.md").read_text()
+
+
+def step_block(text: str, header: str) -> str:
+    match = re.search(
+        rf"(^{re.escape(header)}.*?)(?=^## )",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"Could not find block for {header}")
+    return match.group(1)
+
+
+class LoopNextCommandHandoffTest(unittest.TestCase):
+    def test_next_ticket_empty_backlog_names_create_ticket(self):
+        block = step_block(skill_text("next-ticket"), "## Step 2: Fetch Tickets")
+        self.assertIn("zero actionable tickets", block.lower())
+        self.assertIn("/create-ticket", block)
+
+    def test_next_ticket_done_summary_names_pr_and_ship(self):
+        block = step_block(skill_text("next-ticket"), "## Step 10: Wait for Review")
+        self.assertIn("/pr", block)
+        self.assertIn("/ship", block)
+
+    def test_next_ticket_done_summary_says_review_locally_first(self):
+        block = step_block(skill_text("next-ticket"), "## Step 10: Wait for Review")
+        lower = block.lower()
+        self.assertRegex(
+            lower,
+            r"review locally first|the user reviews first|do not push",
+        )
+
+    def test_next_ticket_still_forbids_auto_push(self):
+        text = skill_text("next-ticket")
+        self.assertIn("Never push or create PRs.", text)
+        step_10 = step_block(text, "## Step 10: Wait for Review")
+        self.assertNotRegex(
+            step_10.lower(),
+            r"run /pr now|then run /pr|proceed to /pr",
+            "handoff names /pr; it must not collapse next-ticket into publishing",
+        )
+
+    def test_create_ticket_filed_summary_names_next_ticket(self):
+        block = step_block(skill_text("create-ticket"), "## Step 8: File")
+        self.assertIn("/next-ticket", block)
+
+    def test_update_deps_summary_names_pr_or_ship(self):
+        block = step_block(
+            skill_text("update-deps"), "## Step 9: Cleanup and Summary"
+        )
+        self.assertTrue(
+            "/pr" in block and "/ship" in block,
+            "update-deps closing summary must name /pr and /ship",
+        )
+        self.assertIn("Never push, create PRs, or merge.", block)
+
+    def test_get_it_right_playbook_names_pr(self):
+        text = skill_text("get-it-right")
+        match = re.search(
+            r"(^### 6\. Output Testing Playbook.*?)(?=^## )",
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, "Could not find get-it-right playbook section")
+        block = match.group(1)
+        self.assertIn("/pr", block)
+        self.assertRegex(
+            block.lower(),
+            r"don't commit|do not commit|review",
+        )
+
+    def test_apply_review_summary_names_ship(self):
+        block = step_block(skill_text("apply-review"), "## Step 10: Summary")
+        self.assertIn("/ship", block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Terminal summaries in `/create-ticket`, `/next-ticket`, `/update-deps`, `/get-it-right`, and `/apply-review` now name the next command in the advertised loop (`/next-ticket`, `/pr`/`/ship`, or `/create-ticket`) while keeping the never-auto-push rule.
- `/update-deps` prints the publish handoff after either closing headline, including the clean success path.
- A validator asserts those handoffs so the seams cannot drift silent again.

## Test plan
- [x] `python -m unittest discover -s tests -p "test_*.py" -t tests -v`
- [x] `ruff check .`
- [ ] Spot-check Filed / Done / dependency-update summaries name the follow-on command

Closes #114