### PR TITLE
fix: quote /pr and /ship descriptions so YAML stays valid

### DIFF
--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -2,7 +2,7 @@
 name: pr
 model: sonnet
 effort: high
-description: Format, lint, test, commit, push, and create a pull request. The cautious "I'm done": opens a PR and stops for CI/review.
+description: "Format, lint, test, commit, push, and create a pull request. The cautious \"I'm done\": opens a PR and stops for CI/review."
 disable-model-invocation: true
 ---
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Commit, push, create/merge PR, sync local default branch, delete branch. The optimistic "I'm done completely": merges and cleans up.
+description: "Commit, push, create/merge PR, sync local default branch, delete branch. The optimistic \"I'm done completely\": merges and cleans up."
 disable-model-invocation: true
 ---
 

--- a/tests/test_skill_frontmatter_yaml.py
+++ b/tests/test_skill_frontmatter_yaml.py
@@ -1,0 +1,67 @@
+"""Skill frontmatter must be valid YAML, or Cursor drops the slash command.
+
+An unquoted `description:` value may not contain `: `. YAML treats that as a
+nested mapping, the parse fails, and plugin-delivered skills vanish from the
+`/` picker. `/pr` and `/ship` hit this after the #111 copy change. The
+existing picker-copy tests read the description line with a regex, so they
+cannot catch it. This walks every shipped SKILL.md.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+# One-line `key: value` entries. Block scalars (`>` / `|`) and quoted values
+# are YAML-legal ways to carry a colon; an unquoted plain scalar is not.
+LINE = re.compile(r"^([A-Za-z0-9_-]+):\s*(.*)$")
+
+
+def frontmatter(path: Path) -> str:
+    text = path.read_text()
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        raise AssertionError(f"{path}: no frontmatter block found")
+    return match.group(1)
+
+
+def skill_paths() -> list[Path]:
+    return sorted(
+        path
+        for path in SKILLS_DIR.iterdir()
+        if path.is_dir() and (path / "SKILL.md").is_file()
+    )
+
+
+class SkillFrontmatterYamlTest(unittest.TestCase):
+    def test_unquoted_frontmatter_values_do_not_contain_colon_space(self):
+        for skill_dir in skill_paths():
+            path = skill_dir / "SKILL.md"
+            with self.subTest(skill=skill_dir.name):
+                for raw in frontmatter(path).splitlines():
+                    line = raw.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    match = LINE.match(line)
+                    if match is None:
+                        continue
+                    value = match.group(2)
+                    if not value or value[0] in "\"'>|{[":
+                        continue
+                    self.assertNotIn(
+                        ": ",
+                        value,
+                        f"{path}: unquoted `{match.group(1)}:` value contains "
+                        "`: `, which is invalid YAML and hides the skill from "
+                        "Cursor's slash picker. Quote the value or drop the "
+                        "colon.",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Quote the `/pr` and `/ship` `description:` fields so the unquoted `: ` from #111 is legal YAML again.
- Cursor was dropping both slash commands from the picker because the plugin frontmatter failed to parse; `/convert-worktree` stayed visible because its YAML was already valid.
- Add a validator that walks every shipped `SKILL.md` so an unquoted colon-space cannot hide a skill again.

## Test plan
- [ ] Run `python3 -m unittest discover -s tests -p "test_*.py" -t tests -q`
- [ ] After this ships in a release (or the 1.2.4 plugin cache is updated), reload Cursor and confirm `/pr` and `/ship` appear in the slash picker
- [ ] In Claude Code, confirm `/agentic-toolkit:pr` and `/agentic-toolkit:ship` register alongside the other prefixed skills