### PR TITLE
fix(skills): require Use when prefix on skill descriptions

### DIFF
--- a/skills/apply-review/SKILL.md
+++ b/skills/apply-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apply-review
-description: Read PR review comments, validate against code, fix valid ones, push, resolve addressed threads, and explain unresolved ones.
+description: Use when a PR has review comments to address. Validates feedback against code, fixes valid items, pushes, and resolves threads.
 argument-hint: "[<pr-number>]"
 ---
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+description: Use when finishing a task or before merge. Dispatches an isolated reviewer subagent on all branch work (committed and uncommitted).
 ---
 
 # Code Review

--- a/skills/compress-markdown/SKILL.md
+++ b/skills/compress-markdown/SKILL.md
@@ -2,10 +2,9 @@
 name: compress-markdown
 model: sonnet
 description: >
-  Compress markdown files into concise prose to save input tokens. Default mode reduces
+  Use when markdown files need compressing to save tokens. Default mode reduces
   verbosity without losing information. With deep, verifies each section against the
   codebase first, removing stale or incorrect content before compressing.
-  Trigger: /compress-markdown [deep] <filepath>
 ---
 
 # Compress Markdown

--- a/skills/convert-worktree/SKILL.md
+++ b/skills/convert-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: convert-worktree
-description: Convert a git worktree into a local branch. Rebase onto latest default branch, clean up project resources, remove worktree, checkout branch in main workspace. Use when finishing work in a worktree.
+description: Use when finishing work in a git worktree. Rebases onto default branch, cleans up resources, removes the worktree, and checks out the branch in the main workspace.
 disable-model-invocation: true
 ---
 

--- a/skills/create-ticket/SKILL.md
+++ b/skills/create-ticket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-ticket
-description: Craft a well-researched, well-structured ticket from a user-provided idea. Explores project context when available, researches prior art, asks clarifying questions only when options are too nuanced to auto-resolve, deduplicates against the existing backlog, and files one world-class ticket. Works for new or mature codebases.
+description: Use when you have an idea to file. Researches context and prior art, dedupes the backlog, and files one well-structured ticket.
 argument-hint: "[idea]"
 ---
 

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -2,7 +2,7 @@
 name: pr
 model: sonnet
 effort: high
-description: "Format, lint, test, commit, push, and create a pull request. The cautious \"I'm done\": opens a PR and stops for CI/review."
+description: "Use when work is done but you want review first. Formats, lints, tests, commits, pushes, and opens a PR. The cautious \"I'm done\": stops for CI/review."
 disable-model-invocation: true
 ---
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: "Commit, push, create/merge PR, sync local default branch, delete branch. The optimistic \"I'm done completely\": merges and cleans up."
+description: "Use when work is done and ready to land. Commits, pushes, create/merge PR, syncs default branch, and deletes the branch. The optimistic \"I'm done completely\": merges and cleans up."
 disable-model-invocation: true
 ---
 

--- a/skills/triage-architecture/SKILL.md
+++ b/skills/triage-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-architecture
-description: Audits a codebase for bugs, security vulnerabilities, missing error handling, race conditions, architectural gaps, DRY violations, naming inconsistencies, incomplete implementations, and robustness issues. Caches tickets to disk, then spawns 4 parallel sub-agents (one per focus cluster) to scrutinize and file tickets.
+description: Use when auditing a codebase for structural and safety issues. Caches tickets to disk, then spawns 4 parallel sub-agents (one per focus cluster) to scrutinize and file tickets.
 argument-hint: "[create | refine [<duration>]]"
 ---
 

--- a/skills/triage-bugs/SKILL.md
+++ b/skills/triage-bugs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-bugs
-description: Investigates a codebase for proven defects using adversarial 4-pass analysis (frame, trace, falsify, prove). Caches tickets to disk, then spawns 4 parallel sub-agents (one per bug category) to find, prove, and document bugs with enough rigor that a skeptical maintainer could fix each from the report alone.
+description: Use when hunting proven defects. Adversarial 4-pass analysis (frame, trace, falsify, prove). Caches tickets to disk, then spawns 4 parallel sub-agents (one per bug category) to find, prove, and document bugs with enough rigor that a skeptical maintainer could fix each from the report alone.
 argument-hint: "[create | refine [<duration>]]"
 ---
 

--- a/skills/triage-product/SKILL.md
+++ b/skills/triage-product/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-product
-description: Audits a project for UX gaps, broken workflows, missing states, confusing terminology, visual inconsistency, navigation/state issues, destructive action safety, data presentation, accessibility issues, and competitive table stakes. Caches tickets to disk, then spawns 4 parallel sub-agents (one per focus cluster) to scrutinize and file tickets.
+description: Use when auditing product UX and workflows. Caches tickets to disk, then spawns 4 parallel sub-agents (one per focus cluster) to scrutinize and file tickets.
 argument-hint: "[create | refine [<duration>]]"
 ---
 

--- a/skills/update-deps/SKILL.md
+++ b/skills/update-deps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-deps
-description: Updates project dependencies. Checks open bot PRs for CVE patches, applies safe minor/patch updates, and researches/fixes breaking changes for major bumps. Optional scope (frontend|backend|infra|all) and major flag.
+description: Use when dependencies need updating. Checks bot PRs for CVEs, applies safe minor/patch bumps, and researches major breaking changes. Optional scope and major flag.
 argument-hint: "[<scope>[|<scope>...]] [major]"
 ---
 

--- a/tests/test_skill_description_prefix.py
+++ b/tests/test_skill_description_prefix.py
@@ -1,0 +1,66 @@
+"""Every shipped skill description starts with Use when for picker branding."""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+PREFIX = "Use when "
+
+
+def skill_paths() -> list[Path]:
+    return sorted(
+        path
+        for path in SKILLS_DIR.iterdir()
+        if path.is_dir() and (path / "SKILL.md").is_file()
+    )
+
+
+def frontmatter(path: Path) -> str:
+    text = path.read_text()
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        raise AssertionError(f"{path}: no frontmatter block found")
+    return match.group(1)
+
+
+def description_text(path: Path) -> str:
+    lines = frontmatter(path).splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith("description:"):
+            continue
+        rest = line[len("description:") :].strip()
+        if rest in (">", "|"):
+            parts: list[str] = []
+            for cont in lines[index + 1 :]:
+                if cont and not cont[0].isspace():
+                    break
+                parts.append(cont.strip())
+            return " ".join(parts)
+        if rest.startswith('"'):
+            return json.loads(rest)
+        if rest.startswith("'"):
+            return rest[1:-1]
+        return rest
+    raise AssertionError(f"{path}: frontmatter has no description")
+
+
+class SkillDescriptionPrefixTest(unittest.TestCase):
+    def test_descriptions_start_with_use_when(self) -> None:
+        for skill_dir in skill_paths():
+            path = skill_dir / "SKILL.md"
+            with self.subTest(skill=skill_dir.name):
+                desc = description_text(path)
+                self.assertTrue(
+                    desc.startswith(PREFIX),
+                    f"{path}: description must start with {PREFIX!r}, got {desc[:40]!r}...",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/triage_shared/skills.py
+++ b/triage_shared/skills.py
@@ -14,12 +14,9 @@ generated output easy to diff and review.
 ARCHITECTURE = {
     # frontmatter
     "description": (
-        "Audits a codebase for bugs, security vulnerabilities, missing "
-        "error handling, race conditions, architectural gaps, DRY "
-        "violations, naming inconsistencies, incomplete implementations, "
-        "and robustness issues. Caches tickets to disk, then spawns 4 "
-        "parallel sub-agents (one per focus cluster) to scrutinize and "
-        "file tickets."
+        "Use when auditing a codebase for structural and safety issues. "
+        "Caches tickets to disk, then spawns 4 parallel sub-agents (one "
+        "per focus cluster) to scrutinize and file tickets."
     ),
     "title": "Triage Architecture",
     # orchestrator preamble (sentence after "You are an **orchestrator**.")
@@ -296,11 +293,11 @@ ARCHITECTURE = {
 # triage-bugs data
 BUGS = {
     "description": (
-        "Investigates a codebase for proven defects using adversarial "
-        "4-pass analysis (frame, trace, falsify, prove). Caches tickets "
-        "to disk, then spawns 4 parallel sub-agents (one per bug "
-        "category) to find, prove, and document bugs with enough rigor "
-        "that a skeptical maintainer could fix each from the report alone."
+        "Use when hunting proven defects. Adversarial 4-pass analysis "
+        "(frame, trace, falsify, prove). Caches tickets to disk, then "
+        "spawns 4 parallel sub-agents (one per bug category) to find, "
+        "prove, and document bugs with enough rigor that a skeptical "
+        "maintainer could fix each from the report alone."
     ),
     "title": "Triage Bugs",
     "orchestrator_role": (
@@ -663,12 +660,9 @@ BUGS = {
 # triage-product data
 PRODUCT = {
     "description": (
-        "Audits a project for UX gaps, broken workflows, missing states, "
-        "confusing terminology, visual inconsistency, navigation/state "
-        "issues, destructive action safety, data presentation, "
-        "accessibility issues, and competitive table stakes. Caches "
-        "tickets to disk, then spawns 4 parallel sub-agents (one per "
-        "focus cluster) to scrutinize and file tickets."
+        "Use when auditing product UX and workflows. Caches tickets to "
+        "disk, then spawns 4 parallel sub-agents (one per focus cluster) "
+        "to scrutinize and file tickets."
     ),
     "title": "Triage Product",
     "orchestrator_role": (


### PR DESCRIPTION
## Summary
- Standardize every shipped skill `description` to start with `Use when` so picker copy is recognizable in harnesses that do not namespace commands (e.g. Cursor)
- Sharpen generic descriptions, especially `code-review`, with skill-specific detail
- Add `tests/test_skill_description_prefix.py` to enforce the convention

## Test plan
- [x] `python3 -m unittest discover -s tests -q`